### PR TITLE
Fix dataset path in Perceptron notebook

### DIFF
--- a/lessons/3-NeuralNetworks/03-Perceptron/Perceptron.ipynb
+++ b/lessons/3-NeuralNetworks/03-Perceptron/Perceptron.ipynb
@@ -762,7 +762,7 @@
     "# !wget https://github.com/microsoft/AI-For-Beginners/raw/main/data/mnist.pkl.gz?raw=true\n",
     "# In this case correct the link to the dataset below as well.\n",
     "\n",
-    "with gzip.open('../../data/mnist.pkl.gz', 'rb') as mnist_pickle:\n",
+    "with gzip.open('../../../data/mnist.pkl.gz', 'rb') as mnist_pickle:\n",
     "    MNIST = pickle.load(mnist_pickle, encoding='latin1')"
    ]
   },


### PR DESCRIPTION
This pull request includes a small but important fix to the dataset path in the Perceptron lesson notebook. The path to the MNIST dataset file was updated to ensure the file can be loaded correctly. 

* Updated the file path in `Perceptron.ipynb` to point to the correct location of the `mnist.pkl.gz` dataset.

Fixes #569 