### PR TITLE
Fix links in setup.md for curriculum usage

### DIFF
--- a/lessons/0-course-setup/setup.md
+++ b/lessons/0-course-setup/setup.md
@@ -7,7 +7,7 @@ Get started with the following resources:
 * [Student Hub page](https://docs.microsoft.com/learn/student-hub?WT.mc_id=academic-77998-cacaste) On this page, you will find beginner resources, Student packs, and even ways to get a free cert voucher. This is one page you want to bookmark and check from time to time as we switch out content at least monthly.
 * [Microsoft Student Learn ambassadors](https://studentambassadors.microsoft.com?WT.mc_id=academic-77998-cacaste) Join a global community of student ambassadors, this could be your way into Microsoft.
 
-**Students**, there are a couple of ways to use the curriculum. First of all, you can just read the text and look through the code directly on GitHub. If you want to run the code in any of the notebooks - [read our instructions](./etc/how-to-run.md), and find more advice on how to do it [in this blog post](https://soshnikov.com/education/how-to-execute-notebooks-from-github/).
+**Students**, there are a couple of ways to use the curriculum. First of all, you can just read the text and look through the code directly on GitHub. If you want to run the code in any of the notebooks - [read our instructions](./how-to-run.md), and find more advice on how to do it [in this blog post](https://soshnikov.com/education/how-to-execute-notebooks-from-github/).
 
 > **Note**: [Instructions on how to run the code in this curriculum](./how-to-run.md)
 
@@ -25,7 +25,7 @@ However, if you would like to take the course as a self-study project, we sugges
 
 > For further study, we recommend following these [Microsoft Learn](https://docs.microsoft.com/en-us/users/dmitrysoshnikov-9132/collections/31zgizg2p418yo/?WT.mc_id=academic-77998-cacaste) modules and learning paths.
 
-**Teachers**, we have [included some suggestions](/for-teachers.md) on how to use this curriculum.
+**Teachers**, we have [included some suggestions](./for-teachers.md) on how to use this curriculum.
 
 ---
 


### PR DESCRIPTION
This pull request makes minor improvements to the `setup.md` file by correcting internal links to ensure they work properly in the documentation.

- Link corrections:
  * Updated the link to the instructions for running code notebooks from `./etc/how-to-run.md` to `./how-to-run.md` for accuracy.
  * Changed the link to the teacher suggestions file from an absolute path `/for-teachers.md` to a relative path `./for-teachers.md` for consistency.
  
  Fixes #568 