### PR TITLE
fix: correct pip command typo and update gensim version in Lesson 5 NLP

### DIFF
--- a/lessons/5-NLP/README.md
+++ b/lessons/5-NLP/README.md
@@ -28,7 +28,7 @@ If you are using local Python installation to run this course, you may need to i
 
 **For PyTorch**
 ```bash
-pip install -r requirements-torch.txt
+pip install -r requirements-pytorch.txt
 ```
 **For TensorFlow**
 ```bash

--- a/lessons/5-NLP/requirements-pytorch.txt
+++ b/lessons/5-NLP/requirements-pytorch.txt
@@ -1,4 +1,4 @@
-gensim>=4.3.0
+gensim>=4.3.0,<5
 huggingface==0.0.1
 matplotlib
 nltk==3.9.4

--- a/lessons/5-NLP/requirements-pytorch.txt
+++ b/lessons/5-NLP/requirements-pytorch.txt
@@ -1,4 +1,4 @@
-gensim==3.8.3
+gensim>=4.3.0
 huggingface==0.0.1
 matplotlib
 nltk==3.9.4


### PR DESCRIPTION
Fixes #632
Two issues fixed in the Lesson 5 NLP setup:

Corrected a typo in README.md: requirements-torch.txt → requirements-pytorch.txt (the former file doesn't exist)
Updated gensim==3.8.3 to gensim>=4.3.0 in requirements-pytorch.txt (the pinned version fails to build on Python 3.10+ due to a NumPy compatibility issue)