### PR TITLE
docs: fix 404 links for beginner-friendly AI examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,10 +6,10 @@ Welcome! This directory contains simple, standalone examples to help you get sta
 
 | Example | Description | Difficulty | Prerequisites |
 |---------|-------------|------------|---------------|
-| [Hello AI World](./01-hello-ai-world.py) | Your first AI program - simple pattern recognition | ⭐ Beginner | Python basics |
-| [Simple Neural Network](./02-simple-neural-network.py) | Build a neural network from scratch | ⭐⭐ Beginner+ | Python, basic math |
-| [Image Classifier](./03-image-classifier.ipynb) | Classify images with a pre-trained model | ⭐⭐ Beginner+ | Python, numpy |
-| [Text Sentiment](./04-text-sentiment.py) | Analyze text sentiment (positive/negative) | ⭐⭐ Beginner+ | Python |
+| [Hello AI World](https://github.com/microsoft/AI-For-Beginners/blob/main/examples/01-hello-ai-world.py) | Your first AI program - simple pattern recognition | ⭐ Beginner | Python basics |
+| [Simple Neural Network](https://github.com/microsoft/AI-For-Beginners/blob/main/examples/02-simple-neural-network.py) | Build a neural network from scratch | ⭐⭐ Beginner+ | Python, basic math |
+| [Image Classifier](https://github.com/microsoft/AI-For-Beginners/blob/main/examples/03-image-classifier.ipynb) | Classify images with a pre-trained model | ⭐⭐ Beginner+ | Python, numpy |
+| [Text Sentiment](https://github.com/microsoft/AI-For-Beginners/blob/main/examples/04-text-sentiment.py) | Analyze text sentiment (positive/negative) | ⭐⭐ Beginner+ | Python |
 
 ## 🚀 Getting Started
 


### PR DESCRIPTION
## Summary
The example table in `examples/README.md` linked to the sample scripts with repo-relative paths (`./01-hello-ai-world.py`). Those 404 when the README is rendered anywhere other than the `examples/` directory itself, so a reader who lands on the file from the issue or the repo root cannot open any of the four beginner examples.

## Changes
Point the four example links at absolute GitHub blob URLs so they resolve regardless of where the README is viewed. Lesson links and the rest of the file are unchanged.

## Testing
Verified each of the four target files exists on `main` (blob URLs return 200).

Fixes #645
