### PR TITLE
Fix scorecard artifact upload action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,9 +59,9 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@v7
         with:
-          name: SARIF file
+          name: results-sarif
           path: results.sarif
           retention-days: 5
 


### PR DESCRIPTION
## Summary
Fixes the Scorecard workflow artifact upload failure caused by the deprecated Node 20-era `actions/upload-artifact` version and an invalid artifact name.

## Changes
- Updated `actions/upload-artifact` from the pinned old v3 commit to `actions/upload-artifact@v7`.
- Renamed the SARIF artifact from `SARIF file` to `results-sarif`.

## Behaviour
The Scorecard workflow should now upload the generated `results.sarif` artifact successfully on current GitHub Actions runners using Node 24.

## Why
GitHub Actions is deprecating Node 20, and the existing pinned upload artifact action was no longer suitable. The workflow also failed because the artifact name `SARIF file` was rejected as invalid by the artifact upload API.

## Validation
- Confirmed the workflow change is limited to `.github/workflows/scorecard.yml`.
- Verified the branch is clean after committing.
- Confirmed the fix was pushed to `origin/fix-errors`.

## Result
The Scorecard artifact upload step should complete without the Node version deprecation issue or artifact name validation error.

## Notes
This PR intentionally keeps the fix small and focused on the failing artifact upload step.