### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/lessons/4-ComputerVision/07-ConvNets/pytorchcv.py
+++ b/lessons/4-ComputerVision/07-ConvNets/pytorchcv.py
@@ -134,7 +134,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return True
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):

--- a/lessons/4-ComputerVision/07-ConvNets/tfcv.py
+++ b/lessons/4-ComputerVision/07-ConvNets/tfcv.py
@@ -48,7 +48,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return im.format=='JPEG'
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):

--- a/lessons/4-ComputerVision/08-TransferLearning/pytorchcv.py
+++ b/lessons/4-ComputerVision/08-TransferLearning/pytorchcv.py
@@ -134,7 +134,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return True
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):

--- a/lessons/4-ComputerVision/08-TransferLearning/tfcv.py
+++ b/lessons/4-ComputerVision/08-TransferLearning/tfcv.py
@@ -48,7 +48,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return im.format=='JPEG'
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):


### PR DESCRIPTION
## Description

This PR replaces bare `except:` clauses with `except Exception:` in image validation functions, following Python best practices.

## Changes

- Replace bare `except:` with `except Exception:` in:
  - `lessons/4-ComputerVision/07-ConvNets/tfcv.py`
  - `lessons/4-ComputerVision/07-ConvNets/pytorchcv.py`
  - `lessons/4-ComputerVision/08-TransferLearning/tfcv.py`
  - `lessons/4-ComputerVision/08-TransferLearning/pytorchcv.py`

## Motivation

Bare `except:` clauses catch all exceptions including `SystemExit` and `KeyboardInterrupt`, which can mask serious errors. Using `except Exception:` follows PEP 8 guidelines and prevents masking of critical system exceptions.

## Testing

- Verified syntax correctness
- Maintains same error handling behavior for legitimate exceptions
- Allows system-level exceptions to propagate properly

## Related Issues

Fixes #707

---

Note: Local environment limitations, relying on CI/CD automated testing for full validation.
