### PR TITLE
Fix curriculum typo in neural networks lesson

### DIFF
--- a/lessons/3-NeuralNetworks/README.md
+++ b/lessons/3-NeuralNetworks/README.md
@@ -8,7 +8,7 @@ As we discussed in the introduction, one of the ways to achieve intelligence is 
 
 ## Machine Learning
 
-Neural Networks are a part of a larger discipline called **Machine Learning**, whose goal is to use data to train computer models that are able to solve problems. Machine Learning constitutes a large part of Artificial Intelligence, however, we do not cover classical ML in this curricula.
+Neural Networks are a part of a larger discipline called **Machine Learning**, whose goal is to use data to train computer models that are able to solve problems. Machine Learning constitutes a large part of Artificial Intelligence. However, we do not cover classical ML in this curriculum.
 
 > Visit our separate **[Machine Learning for Beginners](http://github.com/microsoft/ml-for-beginners)** curriculum to learn more about classic Machine Learning.
 


### PR DESCRIPTION
This pull request fixes a grammar error in the Introduction to Neural Networks lesson. The word "curricula" has been corrected to "curriculum" in the Machine Learning section.