### PR TITLE
fix: replace bare except with except Exception in image validation functions

### DIFF
--- a/lessons/4-ComputerVision/07-ConvNets/pytorchcv.py
+++ b/lessons/4-ComputerVision/07-ConvNets/pytorchcv.py
@@ -134,7 +134,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return True
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):

--- a/lessons/4-ComputerVision/07-ConvNets/tfcv.py
+++ b/lessons/4-ComputerVision/07-ConvNets/tfcv.py
@@ -48,7 +48,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return im.format=='JPEG'
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):

--- a/lessons/4-ComputerVision/08-TransferLearning/pytorchcv.py
+++ b/lessons/4-ComputerVision/08-TransferLearning/pytorchcv.py
@@ -134,7 +134,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return True
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):

--- a/lessons/4-ComputerVision/08-TransferLearning/tfcv.py
+++ b/lessons/4-ComputerVision/08-TransferLearning/tfcv.py
@@ -48,7 +48,7 @@ def check_image(fn):
         im = Image.open(fn)
         im.verify()
         return im.format=='JPEG'
-    except:
+    except Exception:
         return False
     
 def check_image_dir(path):


### PR DESCRIPTION
Fixes #707

## Description
This PR replaces bare `except:` clauses with `except Exception:` in image 
validation functions, following Python best practices (PEP 8).

## Changes
Replaced bare `except:` with `except Exception:` in:
- lessons/4-ComputerVision/07-ConvNets/tfcv.py
- lessons/4-ComputerVision/07-ConvNets/pytorchcv.py
- lessons/4-ComputerVision/08-TransferLearning/tfcv.py
- lessons/4-ComputerVision/08-TransferLearning/pytorchcv.py

## Motivation
Bare `except:` clauses catch all exceptions, including `SystemExit` and 
`KeyboardInterrupt`, which can mask serious errors and prevent users from 
stopping the program (e.g., via Ctrl+C). Using `except Exception:` follows 
PEP 8 guidelines and prevents masking of critical system exceptions, while 
still catching all legitimate errors like corrupt or invalid image files.

## Testing
- Verified syntax correctness with `python -m py_compile`
- Maintains the same error handling behavior for legitimate exceptions
- Allows system-level exceptions (KeyboardInterrupt, SystemExit) to 
  propagate properly