### PR TITLE
Fix broken Word Embeddings lesson link

### DIFF
--- a/lessons/5-NLP/README.md
+++ b/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ If you're interested in learning about NLP from a classic ML perspective, visit 
 In this section we will learn about:
 
 * [Representing text as tensors](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Language Modeling](15-LanguageModeling/README.md)
 * [Recurrent Neural Networks](16-RNN/README.md)
 * [Generative Networks](17-GenerativeNetworks/README.md)


### PR DESCRIPTION
## Summary

- Fix the Word Embeddings link in the NLP curriculum contents.
- Point the link to the existing `14-Embeddings` lesson directory.

## Why

The link used the misspelled path `14-Emdeddings`, which led readers to a missing page.

## Validation

- Confirmed `lessons/5-NLP/14-Embeddings/README.md` exists.
- Ran `git diff --check` successfully.
