### PR TITLE
fix(ta): restore Tamil translation in README

### DIFF
--- a/translations/ta/README.md
+++ b/translations/ta/README.md
@@ -12,25 +12,25 @@
 
 [![Microsoft Foundry Discord](https://dcbadge.limes.pink/api/server/nTYy5BXMWG)](https://discord.gg/nTYy5BXMWG)
 
-# शुरुआती लोगों के लिए कृत्रिम बुद्धिमत्ता - एक पाठ्यक्रम
+# ஆரம்ப நிலை கற்க人工 அறிவியல் பாடத்திட்டம்
 
 |![Sketchnote by @girlie_mac https://twitter.com/girlie_mac](https://github.com/microsoft/AI-For-Beginners/raw/main/lessons/sketchnotes/ai-overview.png)|
 |:---:|
-| शुरुआती लोगों के लिए AI - _स्केच नोट द्वारा [@girlie_mac](https://twitter.com/girlie_mac)_ |
+| AI For Beginners - _அங்கீகாரம்: [@girlie_mac](https://twitter.com/girlie_mac)_ тарабынан உருவாக்கப்பட்டது |
 
-हमारे 12 सप्ताह, 24 पाठ्यक्रम के साथ **कृत्रिम बुद्धिमत्ता** (AI) की दुनिया का अन्वेषण करें! इसमें व्यावहारिक पाठ, प्रश्नोत्तरी, और प्रयोगशाला शामिल हैं। यह पाठ्यक्रम शुरुआती के अनुकूल है और TensorFlow और PyTorch जैसे उपकरणों के साथ-साथ AI में नैतिकता को भी कवर करता है।
+**கற்க人工 அறிவியல்** (AI) உலகத்தைக் 12 வாரங்கள், 24 பாடங்களை கொண்ட பாடத்திட்டத்துடன் ஆராயுங்கள்! இதில் நடைமுறை பாடங்கள், வினாக்கள் மற்றும் ஆய்வுக்கூடங்கள் உள்ளன. இந்த பாடத்திட்டம் ஆரம்ப நிலைக்கேadecimalப்படுத்தப்பட்டும் TensorFlow, PyTorch போன்ற கருவிகளையும், AI இல் உள்ள எதிக்களைவும் கையாள்கிறது.
 
 
-### 🌐 बहुभाषी समर्थन
+### 🌐 பல்மொழி ஆதரவு
 
-#### GitHub क्रिया के माध्यम से समर्थित (स्वचालित और हमेशा अद्यतन)
+#### GitHub செயல்பாடு மூலம் ஆதரிக்கப்படுகிறது (தானாகவும் எப்போதும் புதுப்பிக்கப்படும்)
 
 <!-- CO-OP TRANSLATOR LANGUAGES TABLE START -->
-[Arabic](../ar/README.md) | [Bengali](../bn/README.md) | [Bulgarian](../bg/README.md) | [Burmese (Myanmar)](../my/README.md) | [Chinese (Simplified)](../zh-CN/README.md) | [Chinese (Traditional, Hong Kong)](../zh-HK/README.md) | [Chinese (Traditional, Macau)](../zh-MO/README.md) | [Chinese (Traditional, Taiwan)](../zh-TW/README.md) | [Croatian](../hr/README.md) | [Czech](../cs/README.md) | [Danish](../da/README.md) | [Dutch](../nl/README.md) | [Estonian](../et/README.md) | [Finnish](../fi/README.md) | [French](../fr/README.md) | [German](../de/README.md) | [Greek](../el/README.md) | [Hebrew](../he/README.md) | [Hindi](../hi/README.md) | [Hungarian](../hu/README.md) | [Indonesian](../id/README.md) | [Italian](../it/README.md) | [Japanese](../ja/README.md) | [Kannada](../kn/README.md) | [Khmer](../km/README.md) | [Korean](../ko/README.md) | [Lithuanian](../lt/README.md) | [Malay](../ms/README.md) | [Malayalam](../ml/README.md) | [Marathi](../mr/README.md) | [Nepali](../ne/README.md) | [Nigerian Pidgin](../pcm/README.md) | [Norwegian](../no/README.md) | [Persian (Farsi)](../fa/README.md) | [Polish](../pl/README.md) | [Portuguese (Brazil)](../pt-BR/README.md) | [Portuguese (Portugal)](../pt-PT/README.md) | [Punjabi (Gurmukhi)](../pa/README.md) | [Romanian](../ro/README.md) | [Russian](../ru/README.md) | [Serbian (Cyrillic)](../sr/README.md) | [Slovak](../sk/README.md) | [Slovenian](../sl/README.md) | [Spanish](../es/README.md) | [Swahili](../sw/README.md) | [Swedish](../sv/README.md) | [Tagalog (Filipino)](../tl/README.md) | [Tamil](./README.md) | [Telugu](../te/README.md) | [Thai](../th/README.md) | [Turkish](../tr/README.md) | [Ukrainian](../uk/README.md) | [Urdu](../ur/README.md) | [Vietnamese](../vi/README.md)
+[Arabic](../ar/README.md) | [Bengali](../bn/README.md) | [Bulgarian](../bg/README.md) | [Burmese (Myanmar)](../my/README.md) | [Chinese (Simplified)](../zh-CN/README.md) | [Chinese (Traditional, Hong Kong)](../zh-HK/README.md) | [Chinese (Traditional, Macau)](../zh-MO/README.md) | [Chinese (Traditional, Taiwan)](../zh-TW/README.md) | [Croatian](../hr/README.md) | [Czech](../cs/README.md) | [Danish](../da/README.md) | [Dutch](../nl/README.md) | [Estonian](../et/README.md) | [Finnish](../fi/README.md) | [French](../fr/README.md) | [German](../de/README.md) | [Greek](../el/README.md) | [Hebrew](../he/README.md) | [Hindi](../hi/README.md) | [Hungarian](../hu/README.md) | [Indonesian](../id/README.md) | [Italian](../it/README.md) | [Japanese](../ja/README.md) | [Kannada](../kn/README.md) | [Korean](../ko/README.md) | [Lithuanian](../lt/README.md) | [Malay](../ms/README.md) | [Malayalam](../ml/README.md) | [Marathi](../mr/README.md) | [Nepali](../ne/README.md) | [Nigerian Pidgin](../pcm/README.md) | [Norwegian](../no/README.md) | [Persian (Farsi)](../fa/README.md) | [Polish](../pl/README.md) | [Portuguese (Brazil)](../pt-BR/README.md) | [Portuguese (Portugal)](../pt-PT/README.md) | [Punjabi (Gurmukhi)](../pa/README.md) | [Romanian](../ro/README.md) | [Russian](../ru/README.md) | [Serbian (Cyrillic)](../sr/README.md) | [Slovak](../sk/README.md) | [Slovenian](../sl/README.md) | [Spanish](../es/README.md) | [Swahili](../sw/README.md) | [Swedish](../sv/README.md) | [Tagalog (Filipino)](../tl/README.md) | [Tamil](./README.md) | [Telugu](../te/README.md) | [Thai](../th/README.md) | [Turkish](../tr/README.md) | [Ukrainian](../uk/README.md) | [Urdu](../ur/README.md) | [Vietnamese](../vi/README.md)
 
-> **स्थानीय रूप से क्लोन करना पसंद करते हैं?**
+> **உள்ளூரில் கிளோன் செய்ய விரும்புகிறீர்களா?**
 >
-> इस रिपोजिटरी में 50+ भाषा अनुवाद शामिल हैं जो डाउनलोड आकार को काफी बढ़ाते हैं। अनुवादों के बिना क्लोन करने के लिए स्पार्स चेकआउट का उपयोग करें:
+> இந்த 50+ மொழி மொழிபெயர்ப்புகளை கொண்ட உள்ளமை நிரலில் பதிவிறக்க அளவை பெரிதும் அதிகரிக்கும். மொழிபெயர்ப்புகள் இல்லாமல் கிளோன் செய்ய, sparse checkout ஐப் பயன்படுத்தவும்:
 >
 > **Bash / macOS / Linux:**
 > ```bash
@@ -46,132 +46,132 @@
 > git sparse-checkout set --no-cone "/*" "!translations" "!translated_images"
 > ```
 >
-> यह आपको तेज डाउनलोड के साथ कोर्स पूरा करने के लिए आवश्यक सभी चीज़ें देगा।
+> இது விரைவாக பதிவிறக்க பயன்படுத்த தேவையான அனைத்தையும் தருகிறது.
 <!-- CO-OP TRANSLATOR LANGUAGES TABLE END -->
 
-**यदि आप अतिरिक्त अनुवाद भाषाओं का समर्थन चाहते हैं, तो वे [यहाँ](https://github.com/Azure/co-op-translator/blob/main/getting_started/supported-languages.md) सूचीबद्ध हैं।**
+**மேலும் மொழிபெயர்ப்புகளுக்கு ஆதரவு விரும்பினால் இங்கு காணவும் [here](https://github.com/Azure/co-op-translator/blob/main/getting_started/supported-languages.md)**
 
-## समुदाय में शामिल हों
+## சமுதாயத்தில் சேரவும்
 [![Microsoft Foundry Discord](https://dcbadge.limes.pink/api/server/nTYy5BXMWG)](https://discord.gg/nTYy5BXMWG)
 
-## आप क्या सीखेंगे
+## நீங்கள் கற்கப்போகும் விஷயங்கள்
 
-**[कोर्स का माइंडमैप](http://soshnikov.com/courses/ai-for-beginners/mindmap.html)**
+**[பாடநெறியின் மன மேப்பிங்](http://soshnikov.com/courses/ai-for-beginners/mindmap.html)**
 
-इस पाठ्यक्रम में, आप सीखेंगे:
+இந்த பாடத்திட்டத்தில் நீங்கள் கற்கப்போகும் விஷயங்கள்:
 
-* कृत्रिम बुद्धिमत्ता के विभिन्न दृष्टिकोण, जिसमें "अच्छा पुराना" प्रतीकात्मक दृष्टिकोण **ज्ञान प्रतिनिधित्व** और तर्क के साथ शामिल हैं ([GOFAI](https://en.wikipedia.org/wiki/Symbolic_artificial_intelligence))।
-* **न्यूरल नेटवर्क** और **डीप लर्निंग**, जो आधुनिक AI के मूल में हैं। हम इन महत्वपूर्ण विषयों के पीछे की अवधारणाओं को दो सबसे लोकप्रिय फ्रेमवर्क - [TensorFlow](http://Tensorflow.org) और [PyTorch](http://pytorch.org) में कोड का उपयोग करके समझाएंगे।
-* छवियों और पाठ के लिए **न्यूरल आर्किटेक्चर**। हम हाल के मॉडल कवर करेंगे लेकिन शायद सबसे नवीनतम स्थिति में कुछ कमी हो सकती है।
-* कम लोकप्रिय AI दृष्टिकोण, जैसे **जेनेटिक एल्गोरिदम** और **मल्टी-एजेंट सिस्टम**।
+* "நற்சமயம்" குறியீட்டுக் கலைகள் (**Knowledge Representation**) மற்றும் காரணித்தன்மை உட்பட பல்வேறு செயற்கையறிவு அணுகுமுறைகள் ([GOFAI](https://en.wikipedia.org/wiki/Symbolic_artificial_intelligence)).
+* நவீன AI உடைய அங்கமாகிய **நுரையீரல் வலையமைப்புகள்** மற்றும் **ஆழ்ந்த கற்று முன்னேற்றம்**. இந்த முக்கியபட்ட கருத்துக்களை [TensorFlow](http://Tensorflow.org) மற்றும் [PyTorch](http://pytorch.org) ஆகிய இரு பிரபலமான கட்டமைப்புகளில் கற்றுக்ககுறியீடு மூலம் விளக்குவோம்.
+* படங்கள் மற்றும் உரைகளுடன் பணியாற்ற **நுரையீரல் கட்டமைப்புகள்**. சமீபத்திய மாதிரிகள் பற்றி பேசுவோம், ஆனால் ஆதி நிலைமையிலிருந்து சில விதிமுறைகளை அடையாமலும் இருக்கலாம்.
+* குறைவான பிரபலமுள்ள AI அணுகுமுறைகள், உதாரணமாக **மரபணு கணக்கியல்** மற்றும் **பல முகவர் அமைப்புகள்**.
 
-इस पाठ्यक्रम में हम क्या नहीं कवर करेंगे:
+இந்த பாடத்திட்டத்தில் சேராதவை:
 
-> [इस कोर्स के लिए सभी अतिरिक्त संसाधनों को हमारे Microsoft Learn संग्रह में देखें](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum)
+> [இந்த பாடத்திட்டத்திற்கு அனைத்து கூடுதல் வளங்களையும் Microsoft Learn சேகரிப்பில் காண்க](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum)
 
-* **व्यवसाय में AI** के व्यावसायिक मामले। Microsoft Learn पर [बिजनेस उपयोगकर्ताओं के लिए AI का परिचय](https://docs.microsoft.com/learn/paths/introduction-ai-for-business-users/?WT.mc_id=academic-77998-bethanycheum) या [AI व्यवसाय स्कूल](https://www.microsoft.com/ai/ai-business-school/?WT.mc_id=academic-77998-bethanycheum), जिसे [INSEAD](https://www.insead.edu/) के साथ सहयोग में विकसित किया गया है, लेना consider करें।
-* **क्लासिक मशीन लर्निंग**, जो हमारे [बिगिनर्स के लिए मशीन लर्निंग पाठ्यक्रम](http://github.com/Microsoft/ML-for-Beginners) में अच्छी तरह से वर्णित है।
-* व्यावहारिक AI एप्लिकेशन जो **[कॉग्निटिव सर्विसेज](https://azure.microsoft.com/services/cognitive-services/?WT.mc_id=academic-77998-bethanycheum)** का उपयोग करके बनाए गए हैं। इसके लिए, हम सलाह देते हैं कि आप Microsoft Learn के मॉड्यूल से शुरू करें जैसे [दृश्य](https://docs.microsoft.com/learn/paths/create-computer-vision-solutions-azure-cognitive-services/?WT.mc_id=academic-77998-bethanycheum), [प्राकृतिक भाषा प्रसंस्करण](https://docs.microsoft.com/learn/paths/explore-natural-language-processing/?WT.mc_id=academic-77998-bethanycheum), **[Azure OpenAI सेवा के साथ जनरेटिव AI](https://learn.microsoft.com/en-us/training/paths/develop-ai-solutions-azure-openai/?WT.mc_id=academic-77998-bethanycheum)** और अन्य।
-* विशिष्ट ML **क्लाउड फ्रेमवर्क**, जैसे [Azure Machine Learning](https://azure.microsoft.com/services/machine-learning/?WT.mc_id=academic-77998-bethanycheum), [Microsoft Fabric](https://learn.microsoft.com/en-us/training/paths/get-started-fabric/?WT.mc_id=academic-77998-bethanycheum), या [Azure Databricks](https://docs.microsoft.com/learn/paths/data-engineer-azure-databricks?WT.mc_id=academic-77998-bethanycheum)। [Azure Machine Learning के साथ मशीन लर्निंग समाधान बनाएं और संचालित करें](https://docs.microsoft.com/learn/paths/build-ai-solutions-with-azure-ml-service/?WT.mc_id=academic-77998-bethanycheum) और [Azure Databricks के साथ मशीन लर्निंग समाधान बनाएं और संचालित करें](https://docs.microsoft.com/learn/paths/build-operate-machine-learning-solutions-azure-databricks/?WT.mc_id=academic-77998-bethanycheum) सीखने के पाथ का उपयोग करने पर विचार करें।
-* **संवादी AI** और **चैट बॉट्स**। एक अलग [संवादी AI समाधान बनाएं](https://docs.microsoft.com/learn/paths/create-conversational-ai-solutions/?WT.mc_id=academic-77998-bethanycheum) सीखने का पाथ है, और आप अधिक विवरण के लिए [इस ब्लॉग पोस्ट](https://soshnikov.com/azure/hello-bot-conversational-ai-on-microsoft-platform/) को भी देख सकते हैं।
-* डीप लर्निंग के पीछे की **गहरी गणित**। इसके लिए, हम Ian Goodfellow, Yoshua Bengio और Aaron Courville द्वारा लिखित [Deep Learning](https://www.amazon.com/Deep-Learning-Adaptive-Computation-Machine/dp/0262035618) की सिफारिश करते हैं, जो ऑनलाइन भी उपलब्ध है [https://www.deeplearningbook.org/](https://www.deeplearningbook.org/) पर।
+* வணிகத்தில் AI பயன்படுத்தும் வழக்குகள். Microsoft Learn இல் உள்ள [வணிக பயனர்களுக்கான AI அறிமுகம்](https://docs.microsoft.com/learn/paths/introduction-ai-for-business-users/?WT.mc_id=academic-77998-bethanycheum) வழிபடலை எடுத்துக்கொள்ளவும், அல்லது [AI வணிக பள்ளி](https://www.microsoft.com/ai/ai-business-school/?WT.mc_id=academic-77998-bethanycheum) என்பதை [INSEAD](https://www.insead.edu/) உடன் சேர்ந்து உருவாக்கப்பட்டது.
+* பழைய வகை மெஷின் கற்றல், இது நமது [Machine Learning for Beginners Curriculum](http://github.com/Microsoft/ML-for-Beginners) இல் சிறந்த முறையில் விளக்கப்பட்டுள்ளது.
+* நடைமுறை AI பயன்பாடுகள் **[கோக்னிட்டிவ் சர்வீசஸ்](https://azure.microsoft.com/services/cognitive-services/?WT.mc_id=academic-77998-bethanycheum)** கொண்டு உருவாக்கப்படுகின்றன. இதற்காக, Microsoft Learn இல் உள்ள [காட்சி](https://docs.microsoft.com/learn/paths/create-computer-vision-solutions-azure-cognitive-services/?WT.mc_id=academic-77998-bethanycheum), [இயற்கை மொழி செயலாக்கம்](https://docs.microsoft.com/learn/paths/explore-natural-language-processing/?WT.mc_id=academic-77998-bethanycheum), **[Azure OpenAI சேவையுடன் உருவாக்கும் AI](https://learn.microsoft.com/en-us/training/paths/develop-ai-solutions-azure-openai/?WT.mc_id=academic-77998-bethanycheum)** மற்றும் மற்ற தொகுதிகளை தொடங்க பரிந்துரைக்கிறோம்.
+* குறிப்பிட்ட மெஷின் கற்றல் **முக்கடல் கட்டமைப்புகள்**, உதாரணமாக [Azure Machine Learning](https://azure.microsoft.com/services/machine-learning/?WT.mc_id=academic-77998-bethanycheum), [Microsoft Fabric](https://learn.microsoft.com/en-us/training/paths/get-started-fabric/?WT.mc_id=academic-77998-bethanycheum), அல்லது [Azure Databricks](https://docs.microsoft.com/learn/paths/data-engineer-azure-databricks?WT.mc_id=academic-77998-bethanycheum). [Azure Machine Learning உடன் மெஷின் கற்றல் தீர்வுகளை உருவாக்கவும் இயக்கவும்](https://docs.microsoft.com/learn/paths/build-ai-solutions-with-azure-ml-service/?WT.mc_id=academic-77998-bethanycheum) மற்றும் [Azure Databricks உடன் மெஷின் கற்றல் தீர்வுகளை உருவாக்கவும் இயக்கவும்](https://docs.microsoft.com/learn/paths/build-operate-machine-learning-solutions-azure-databricks/?WT.mc_id=academic-77998-bethanycheum) ஆகிய வழிமுறைகளை பயன்படுத்த பரிந்துரைக்கிறோம்.
+* **அரட்டையாடும் AI** மற்றும் **சாட் பாட்டுகள்**. தனித்துவமான [அரட்டையாடும் AI தீர்வுகள் உருவாக்குதல்](https://docs.microsoft.com/learn/paths/create-conversational-ai-solutions/?WT.mc_id=academic-77998-bethanycheum) வழிமுறை உள்ளது, மேலும் [இந்த வலைப்பதிவு பதிவு](https://soshnikov.com/azure/hello-bot-conversational-ai-on-microsoft-platform/) கூட உதவும்.
+* ஆழ்ந்த கற்றலின் பின்னணி உள்ள **ஆழ்ந்த கணிதங்கள்**. இதற்கு, Ian Goodfellow, Yoshua Bengio மற்றும் Aaron Courville எழுதிய [ஆழ்ந்த கற்றல்](https://www.amazon.com/Deep-Learning-Adaptive-Computation-Machine/dp/0262035618) புத்தகத்தை பரிந்துரைக்கிறோம், இது ஆன்லைனிலும் கிடைக்கிறது [https://www.deeplearningbook.org/](https://www.deeplearningbook.org/).
 
-_क्लाउड में AI_ विषयों के लिए एक कोमल परिचय के लिए, आप [Azure पर कृत्रिम बुद्धिमत्ता के साथ शुरू करें](https://docs.microsoft.com/learn/paths/get-started-with-artificial-intelligence-on-azure/?WT.mc_id=academic-77998-bethanycheum) सीखने का पाथ ले सकते हैं।
+_கிளவூட்டில் AI_க்கு மென்மையான அறிமுகம் தேவைப்பட்டால் [Azure இல் செயற்கை அறிவியலுடன் தொடங்கலாம்](https://docs.microsoft.com/learn/paths/get-started-with-artificial-intelligence-on-azure/?WT.mc_id=academic-77998-bethanycheum) கற்றல் பாதையை எடுக்கலாம்.
 
-# सामग्री
+# உள்ளடக்கம்
 
-|     |                                                                 पाठ लिंक                                                                  |                                           PyTorch/Keras/TensorFlow                                          | प्रयोगशाला                                                            |
+|     |                                                                 பாட லின்க்                                                                  |                                           PyTorch/Keras/TensorFlow                                          | ஆய்வுக் கூடம்                                                            |
 | :-: | :------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------ |
-| 0  |                                 [कोर्स सेटअप](./lessons/0-course-setup/setup.md)                                 |                      [अपने विकास वातावरण सेटअप करें](./lessons/0-course-setup/how-to-run.md)                       |   |
-| I  |               [**AI का परिचय**](./lessons/1-Intro/README.md)      | | |
-| 01  |       [AI का परिचय और इतिहास](./lessons/1-Intro/README.md)       |           -                            | -  |
-| II |              **प्रतीकात्मक AI**              |
-| 02  |       [அறிவுத் tenuirkai மற்றும் நிபுணர் அமைப்புகள்](./lessons/2-Symbolic/README.md)       |            [நிபுணர் அமைப்புகள்](./lessons/2-Symbolic/Animals.ipynb) /  [ஒன்டொலஜி](./lessons/2-Symbolic/FamilyOntology.ipynb) /[கருத்து வரைபடம்](./lessons/2-Symbolic/MSConceptGraph.ipynb)                             |  |
-| III |                        [**நரம்பு நெட்வொர்க்குகளுக்கான அறிமுகம்**](./lessons/3-NeuralNetworks/README.md) |||
-| 03  |                [பெர்செப்ட்ரான்](./lessons/3-NeuralNetworks/03-Perceptron/README.md)                 |                       [கையடக்கப்புத்தகம்](./lessons/3-NeuralNetworks/03-Perceptron/Perceptron.ipynb)                      | [லேபு](./lessons/3-NeuralNetworks/03-Perceptron/lab/README.md) |
-| 04  |                   [பல அடுக்குக் பெர்செப்ட்ரான் மற்றும் எங்கள் சொந்த கட்டமைப்பை உருவாக்குதல்](./lessons/3-NeuralNetworks/04-OwnFramework/README.md)                   |        [கையடக்கப்புத்தகம்](./lessons/3-NeuralNetworks/04-OwnFramework/OwnFramework.ipynb)        | [லேபு](./lessons/3-NeuralNetworks/04-OwnFramework/lab/README.md) |
-| 05  |            [கட்டமைப்புகளுக்கு அறிமுகம் (PyTorch/TensorFlow) மற்றும் அதிகபட்சம் மீது பயிற்சி](./lessons/3-NeuralNetworks/05-Frameworks/README.md)             |           [பைடார்ச்](./lessons/3-NeuralNetworks/05-Frameworks/IntroPyTorch.ipynb) / [கெராஸ்](./lessons/3-NeuralNetworks/05-Frameworks/IntroKeras.ipynb) / [டென்சர்ஃப்லோ](./lessons/3-NeuralNetworks/05-Frameworks/IntroKerasTF.ipynb)             | [லேபு](./lessons/3-NeuralNetworks/05-Frameworks/lab/README.md) |
-| IV  |            [**கணினி பார்வை**](./lessons/4-ComputerVision/README.md)             | [பைடார்ச்](https://docs.microsoft.com/learn/modules/intro-computer-vision-pytorch/?WT.mc_id=academic-77998-cacaste) / [டென்சர்ஃப்லோ](https://docs.microsoft.com/learn/modules/intro-computer-vision-TensorFlow/?WT.mc_id=academic-77998-cacaste)| [மைக்ரோசாஃப்ட் அசூர் இல் கணினி பார்வையை ஆராய்க](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum) |
-| 06  |            [கணினி பார்வைக்கு அறிமுகம். OpenCV](./lessons/4-ComputerVision/06-IntroCV/README.md)             |           [கையடக்கப்புத்தகம்](./lessons/4-ComputerVision/06-IntroCV/OpenCV.ipynb)         | [லேபு](./lessons/4-ComputerVision/06-IntroCV/lab/README.md) |
-| 07  |            [மூடிய நரம்பு நெட்வொர்க்குகள்](./lessons/4-ComputerVision/07-ConvNets/README.md) &  [CNN கட்டமைப்புகள்](./lessons/4-ComputerVision/07-ConvNets/CNN_Architectures.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/07-ConvNets/ConvNetsPyTorch.ipynb) /[டென்சர்ஃப்லோ](./lessons/4-ComputerVision/07-ConvNets/ConvNetsTF.ipynb)             | [லேபு](./lessons/4-ComputerVision/07-ConvNets/lab/README.md) |
-| 08  |            [முன் பயிற்சி பெற்ற நெட்வொர்க்குகள் மற்றும் பரிமாற்றக் கற்றல்](./lessons/4-ComputerVision/08-TransferLearning/README.md) மற்றும் [பயிற்சி ட்ரிக்குகள்](./lessons/4-ComputerVision/08-TransferLearning/TrainingTricks.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/08-TransferLearning/TransferLearningPyTorch.ipynb) / [டென்சர்ஃப்லோ](./lessons/3-NeuralNetworks/05-Frameworks/IntroKerasTF.ipynb)             | [லேபு](./lessons/4-ComputerVision/08-TransferLearning/lab/README.md) |
-| 09  |            [ஆட்டோஎன்கோடர்களும் VAEs](./lessons/4-ComputerVision/09-Autoencoders/README.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/09-Autoencoders/AutoEncodersPyTorch.ipynb) / [டென்சர்ஃப்லோ](./lessons/4-ComputerVision/09-Autoencoders/AutoencodersTF.ipynb)             |  |
-| 10  |            [உற்பத்தி எதிரணி நெட்வொர்க்குகள் மற்றும் கலைமயம் பாணி பரிமாற்றம்](./lessons/4-ComputerVision/10-GANs/README.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/10-GANs/GANPyTorch.ipynb) / [டென்சர்ஃப்லோ](./lessons/4-ComputerVision/10-GANs/GANTF.ipynb)             |  |
-| 11  |            [பொருள் கண்டறிதல்](./lessons/4-ComputerVision/11-ObjectDetection/README.md)             |         [டென்சர்ஃப்லோ](./lessons/4-ComputerVision/11-ObjectDetection/ObjectDetection.ipynb)             | [லேபு](./lessons/4-ComputerVision/11-ObjectDetection/lab/README.md) |
-| 12  |            [அர்த்தப்படி பிரிப்பு. U-Net](./lessons/4-ComputerVision/12-Segmentation/README.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/12-Segmentation/SemanticSegmentationPytorch.ipynb) / [டென்சர்ஃப்லோ](./lessons/4-ComputerVision/12-Segmentation/SemanticSegmentationTF.ipynb)             |  |
-| V  |            [**செயற்கை மொழி செயலாக்கம்**](./lessons/5-NLP/README.md)             | [பைடார்ச்](https://docs.microsoft.com/learn/modules/intro-natural-language-processing-pytorch/?WT.mc_id=academic-77998-cacaste) /[டென்சர்ஃப்லோ](https://docs.microsoft.com/learn/modules/intro-natural-language-processing-TensorFlow/?WT.mc_id=academic-77998-cacaste) | [மைக்ரோசாஃப்ட் அசூர் இல் செயற்கை மொழி செயலாக்கத்தை ஆராய்க](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum)|
-| 13  |            [உரை tenuirkai. பேராங்கு/TF-IDF](./lessons/5-NLP/13-TextRep/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/13-TextRep/TextRepresentationPyTorch.ipynb) / [டென்சர்ஃப்லோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/13-TextRep/TextRepresentationTF.ipynb)             | |
-| 14  |            [அர்த்தப்படி வார்த்தை மையமாக்கல்கள். Word2Vec மற்றும் GloVe](./lessons/5-NLP/14-Embeddings/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/14-Embeddings/EmbeddingsPyTorch.ipynb) / [டென்சர்ஃப்லோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/14-Embeddings/EmbeddingsTF.ipynb)             |  |
-| 15  |            [மொழி மாதிரியாக்கல். உங்கள் சொந்த மையமாக்கல்களைப் பயிற்றுவித்தல்](./lessons/5-NLP/15-LanguageModeling/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/15-LanguageModeling/CBoW-PyTorch.ipynb) / [டென்சர்ஃப்லோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/15-LanguageModeling/CBoW-TF.ipynb)             | [லேபு](./lessons/5-NLP/15-LanguageModeling/lab/README.md) |
-| 16  |            [உடன்முறை நரம்பு நெட்வொர்க்குகள்](./lessons/5-NLP/16-RNN/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/16-RNN/RNNPyTorch.ipynb) / [டென்சர்ஃப்லோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/16-RNN/RNNTF.ipynb)             |  |
-| 17  |            [உற்பத்தி உடன்முறை நெட்வொர்க்குகள்](./lessons/5-NLP/17-GenerativeNetworks/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/17-GenerativeNetworks/GenerativePyTorch.ipynb) / [டென்சர்ஃப்லோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/17-GenerativeNetworks/GenerativeTF.ipynb)             | [லேபு](./lessons/5-NLP/17-GenerativeNetworks/lab/README.md) |
-| 18  |            [தரமான மாற்றிகள். BERT.](./lessons/5-NLP/18-Transformers/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/18-Transformers/TransformersPyTorch.ipynb) /[டென்சர்ஃப்லோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/18-Transformers/TransformersTF.ipynb)             |  |
-| 19  |            [பெயர் அடையாள அங்கீகாரம்](./lessons/5-NLP/19-NER/README.md)             |           [டென்சர்ஃப்லோ](https://microsoft.github.io/AI-For-Beginners/lessons/5-NLP/19-NER/NER-TF.ipynb)             | [லேபு](./lessons/5-NLP/19-NER/lab/README.md) |
-| 20  |            [பெரிய மொழி மாதிரிகள், உடற்பொருள் நிரல் மற்றும் சில-காட்சி பணிகள்](./lessons/5-NLP/20-LangModels/README.md)             |           [பைடார்ச்](https://microsoft.github.io/AI-For-Beginners/lessons/5-NLP/20-LangModels/GPT-PyTorch.ipynb) | |
-| VI |            **மற்ற AI தொழில்நுட்பங்கள்** || |
-| 21  |            [உற்றார் மரபணுAlgorithmகள்](./lessons/6-Other/21-GeneticAlgorithms/README.md)             |           [கையடக்கப்புத்தகம்](./lessons/6-Other/21-GeneticAlgorithms/Genetic.ipynb) | |
-| 22  |            [ஆழ்மிக்க வலிமை பயிற்சி](./lessons/6-Other/22-DeepRL/README.md)             |           [பைடார்ச்](./lessons/6-Other/22-DeepRL/CartPole-RL-PyTorch.ipynb) /[டென்சர்ஃப்லோ](./lessons/6-Other/22-DeepRL/CartPole-RL-TF.ipynb)             | [லேபு](./lessons/6-Other/22-DeepRL/lab/README.md) |
-| 23  |            [பன்முக முகவர் அமைப்புகள்](./lessons/6-Other/23-MultiagentSystems/README.md)             |  | |
+| 0  |                                 [கோர்ஸ் அமைப்பு](./lessons/0-course-setup/setup.md)                                 |                      [உங்கள் மேம்பாட்டு சூழலை அமைக்கும் முறை](./lessons/0-course-setup/how-to-run.md)                       |   |
+| I  |               [**AI அறிமுகம்**](./lessons/1-Intro/README.md)      | | |
+| 01  |       [AI அறிமுகம் மற்றும் வரலாறு](./lessons/1-Intro/README.md)       |           -                            | -  |
+| II |              **குறியீட்டு AI**              |
+| 02  |       [அறிவுக் கொள்கை பிரதிநிதித்துவம் மற்றும் நிபுணர் அமைப்புகள்](./lessons/2-Symbolic/README.md)       |            [நிபுணர் அமைப்புகள்](./lessons/2-Symbolic/Animals.ipynb) /  [ஒன்டாலஜி](./lessons/2-Symbolic/FamilyOntology.ipynb) /[கருத்துச் சித்திரம்](./lessons/2-Symbolic/MSConceptGraph.ipynb)                             |  |
+| III |                        [**நியூரல் நெட்வொர்க்குகளுக்கான அறிமுகம்**](./lessons/3-NeuralNetworks/README.md) |||
+| 03  |                [பெர்செப்ட்ரான்](./lessons/3-NeuralNetworks/03-Perceptron/README.md)                 |                       [நோட்புக்](./lessons/3-NeuralNetworks/03-Perceptron/Perceptron.ipynb)                      | [பயிற்சி கூடம்](./lessons/3-NeuralNetworks/03-Perceptron/lab/README.md) |
+| 04  |                   [பல அடுக்கான பெர்செப்ட்ரான் மற்றும் எங்கள் சொந்த கட்டமைப்பை உருவாக்குதல்](./lessons/3-NeuralNetworks/04-OwnFramework/README.md)                   |        [நோட்புக்](./lessons/3-NeuralNetworks/04-OwnFramework/OwnFramework.ipynb)        | [பயிற்சி கூடம்](./lessons/3-NeuralNetworks/04-OwnFramework/lab/README.md) |
+| 05  |            [கட்டமைப்புகளுக்கு அறிமுகம் (பைடார்ச்/டென்சர்ப்ளோ) மற்றும் மேலதிகமாக்கல்](./lessons/3-NeuralNetworks/05-Frameworks/README.md)             |           [பைடார்ச்](./lessons/3-NeuralNetworks/05-Frameworks/IntroPyTorch.ipynb) / [கேராஸ்](./lessons/3-NeuralNetworks/05-Frameworks/IntroKeras.ipynb) / [டென்சர்ப்ளோ](./lessons/3-NeuralNetworks/05-Frameworks/IntroKerasTF.ipynb)             | [பயிற்சி கூடம்](./lessons/3-NeuralNetworks/05-Frameworks/lab/README.md) |
+| IV  |            [**கணினி பார்வை**](./lessons/4-ComputerVision/README.md)             | [பைடார்ச்](https://docs.microsoft.com/learn/modules/intro-computer-vision-pytorch/?WT.mc_id=academic-77998-cacaste) / [டென்சர்ப்ளோ](https://docs.microsoft.com/learn/modules/intro-computer-vision-TensorFlow/?WT.mc_id=academic-77998-cacaste)| [Microsoft Azureல் கணினி பார்வையை ஆராயுங்கள்](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum) |
+| 06  |            [கணினி பார்வைக்கு அறிமுகம். OpenCV](./lessons/4-ComputerVision/06-IntroCV/README.md)             |           [நோட்புக்](./lessons/4-ComputerVision/06-IntroCV/OpenCV.ipynb)         | [பயிற்சி கூடம்](./lessons/4-ComputerVision/06-IntroCV/lab/README.md) |
+| 07  |            [ஈற்றம் நியூரல் நெட்வொர்க்குகள்](./lessons/4-ComputerVision/07-ConvNets/README.md) &  [CNN கட்டமைப்புகள்](./lessons/4-ComputerVision/07-ConvNets/CNN_Architectures.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/07-ConvNets/ConvNetsPyTorch.ipynb) /[டென்சர்ப்ளோ](./lessons/4-ComputerVision/07-ConvNets/ConvNetsTF.ipynb)             | [பயிற்சி கூடம்](./lessons/4-ComputerVision/07-ConvNets/lab/README.md) |
+| 08  |            [முன்னுக்கு பயிற்சி பெற்ற நெட்வொர்க்குகள் மற்றும் மாற்றுப் பயிற்சி](./lessons/4-ComputerVision/08-TransferLearning/README.md) மற்றும் [பயிற்சி கைமுறைகள்](./lessons/4-ComputerVision/08-TransferLearning/TrainingTricks.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/08-TransferLearning/TransferLearningPyTorch.ipynb) / [டென்சர்ப்ளோ](./lessons/3-NeuralNetworks/05-Frameworks/IntroKerasTF.ipynb)             | [பயிற்சி கூடம்](./lessons/4-ComputerVision/08-TransferLearning/lab/README.md) |
+| 09  |            [ஆட்டோஎன்கோடர்கள் மற்றும் VAEகள்](./lessons/4-ComputerVision/09-Autoencoders/README.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/09-Autoencoders/AutoEncodersPyTorch.ipynb) / [டென்சர்ப்ளோ](./lessons/4-ComputerVision/09-Autoencoders/AutoencodersTF.ipynb)             |  |
+| 10  |            [உற்பத்தி எதிர்ப்பு நெட்வொர்க்குகள் மற்றும் கலைப் பாணி மாற்றம்](./lessons/4-ComputerVision/10-GANs/README.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/10-GANs/GANPyTorch.ipynb) / [டென்சர்ப்ளோ](./lessons/4-ComputerVision/10-GANs/GANTF.ipynb)             |  |
+| 11  |            [பொருள் கண்டறிதல்](./lessons/4-ComputerVision/11-ObjectDetection/README.md)             |         [டென்சர்ப்ளோ](./lessons/4-ComputerVision/11-ObjectDetection/ObjectDetection.ipynb)             | [பயிற்சி கூடம்](./lessons/4-ComputerVision/11-ObjectDetection/lab/README.md) |
+| 12  |            [பொருளமைப்பு பிரிவுகள். U-Net](./lessons/4-ComputerVision/12-Segmentation/README.md)             |           [பைடார்ச்](./lessons/4-ComputerVision/12-Segmentation/SemanticSegmentationPytorch.ipynb) / [டென்சர்ப்ளோ](./lessons/4-ComputerVision/12-Segmentation/SemanticSegmentationTF.ipynb)             |  |
+| V  |            [**பொதுவான மொழி செயலாக்கம்**](./lessons/5-NLP/README.md)             | [பைடார்ச்](https://docs.microsoft.com/learn/modules/intro-natural-language-processing-pytorch/?WT.mc_id=academic-77998-cacaste) /[டென்சர்ப்ளோ](https://docs.microsoft.com/learn/modules/intro-natural-language-processing-TensorFlow/?WT.mc_id=academic-77998-cacaste) | [Microsoft Azureல் பொதுவான மொழி செயலாக்கத்தை ஆராயுங்கள்](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum)|
+| 13  |            [வெள்ளிவேட்டை குறியீடு. Bow/TF-IDF](./lessons/5-NLP/13-TextRep/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/13-TextRep/TextRepresentationPyTorch.ipynb) / [டென்சர்ப்ளோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/13-TextRep/TextRepresentationTF.ipynb)             | |
+| 14  |            [பொருள் சொல் சாரங்கள். Word2Vec மற்றும் GloVe](./lessons/5-NLP/14-Embeddings/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/14-Embeddings/EmbeddingsPyTorch.ipynb) / [டென்சர்ப்ளோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/14-Embeddings/EmbeddingsTF.ipynb)             |  |
+| 15  |            [மொழி மாதிரிகை. உங்கள் சொந்த சாரங்களை பயிற்சி செய்தல்](./lessons/5-NLP/15-LanguageModeling/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/15-LanguageModeling/CBoW-PyTorch.ipynb) / [டென்சர்ப்ளோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/15-LanguageModeling/CBoW-TF.ipynb)             | [பயிற்சி கூடம்](./lessons/5-NLP/15-LanguageModeling/lab/README.md) |
+| 16  |            [மறுவரிசை நியூரல் நெட்வொர்க்குகள்](./lessons/5-NLP/16-RNN/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/16-RNN/RNNPyTorch.ipynb) / [டென்சர்ப்ளோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/16-RNN/RNNTF.ipynb)             |  |
+| 17  |            [உற்பத்தியாற்றும் மறுவரிசை நெட்வொர்க்குகள்](./lessons/5-NLP/17-GenerativeNetworks/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/17-GenerativeNetworks/GenerativePyTorch.ipynb) / [டென்சர்ப்ளோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/17-GenerativeNetworks/GenerativeTF.ipynb)             | [பயிற்சி கூடம்](./lessons/5-NLP/17-GenerativeNetworks/lab/README.md) |
+| 18  |            [மாற்றியமைப்பாளர்கள். BERT.](./lessons/5-NLP/18-Transformers/README.md)             |           [பைடார்ச்](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/18-Transformers/TransformersPyTorch.ipynb) /[டென்சர்ப்ளோ](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/18-Transformers/TransformersTF.ipynb)             |  |
+| 19  |            [பெயரிடப்பட்டישות அலகு அடையாளம் காணுதல்](./lessons/5-NLP/19-NER/README.md)             |           [டென்சர்ப்ளோ](https://microsoft.github.io/AI-For-Beginners/lessons/5-NLP/19-NER/NER-TF.ipynb)             | [பயிற்சி கூடம்](./lessons/5-NLP/19-NER/lab/README.md) |
+| 20  |            [பெரிய மொழி மாதிரிகள், ப்ராம்ட் புரோகிராமிங் மற்றும் சில-காட்சி பணிகள்](./lessons/5-NLP/20-LangModels/README.md)             |           [பைடார்ச்](https://microsoft.github.io/AI-For-Beginners/lessons/5-NLP/20-LangModels/GPT-PyTorch.ipynb) | |
+| VI |            **பிற AI தொழில்நுட்பங்கள்** || |
+| 21  |            [ஜெனெட்டிக் அணுகுமுறைகள்](./lessons/6-Other/21-GeneticAlgorithms/README.md)             |           [நோட்புக்](./lessons/6-Other/21-GeneticAlgorithms/Genetic.ipynb) | |
+| 22  |            [ஆழ்ந்த ஊக்கம் கற்றல்](./lessons/6-Other/22-DeepRL/README.md)             |           [பைடார்ச்](./lessons/6-Other/22-DeepRL/CartPole-RL-PyTorch.ipynb) /[டென்சர்ப்ளோ](./lessons/6-Other/22-DeepRL/CartPole-RL-TF.ipynb)             | [பயிற்சி கூடம்](./lessons/6-Other/22-DeepRL/lab/README.md) |
+| 23  |            [பன்முக செயல்பாட்டு அமைப்புகள்](./lessons/6-Other/23-MultiagentSystems/README.md)             |  | |
 | VII |            **AI நெறிமுறைகள்** | | |
-| 24  |            [AI நெறிமுறைகள் மற்றும் பொறுப்புள்ள AI](./lessons/7-Ethics/README.md)             |           [Microsoft Learn: பொறுப்புள்ள AI கொள்கைகள்](https://docs.microsoft.com/learn/paths/responsible-ai-business-principles/?WT.mc_id=academic-77998-cacaste) | |
-| IX  |            **மேலும்** | | |
-| 25  |            [பன்முக நெட்வொர்க்குகள், CLIP மற்றும் VQGAN](./lessons/X-Extras/X1-MultiModal/README.md)             |           [கையடக்கப்புத்தகம்](./lessons/X-Extras/X1-MultiModal/Clip.ipynb)    | |
+| 24  |            [AI நெறிமுறைகள் மற்றும் பொறுப்பான AI](./lessons/7-Ethics/README.md)             |           [Microsoft Learn: பொறுப்பான AI கோட்பாடுகள்](https://docs.microsoft.com/learn/paths/responsible-ai-business-principles/?WT.mc_id=academic-77998-cacaste) | |
+| IX  |            **கூடுதல்** | | |
+| 25  |            [பன்முக நெட்வொர்க்குகள், CLIP மற்றும் VQGAN](./lessons/X-Extras/X1-MultiModal/README.md)             |           [நோட்புக்](./lessons/X-Extras/X1-MultiModal/Clip.ipynb)    | |
 
-## ஒவ்வொரு பாடத்திலும் உள்ளவை
-* வாசிப்புக்கு முன் பொருள்
-* செயல்படுத்தக்கூடிய Jupyter நோட்புக்குகள், உட்கட்டமைப்புக்கு (உதாஃப PyTorch அல்லது TensorFlow) குறிப்பாக இருக்கும். செயல்படுத்தக்கூடிய நோட்புக் நிறைய கோட்பார்வை பொருட்களையும் கொண்டுள்ளது, எனவே தலைப்பை புரிந்துகொள்வதற்கு குறைந்தது ஒரு பதிப்பு நோட்புக் (பிரியோம் PyTorch அல்லது TensorFlow) படிக்க வேண்டும்.
-* சில தலைப்புகளுக்கு **லேப்கள்** கிடைக்கின்றன, அவை நீங்கள் கற்றுக்கொண்ட பொருட்களை ஒரு குறிப்பிட்ட பிரச்சனையில் செயல்படுத்த முயற்சி செய்ய வாய்ப்பளிக்கின்றன.
-* சில பிரிவுகளில் [**MS Learn**](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum) தொகுதிகளுக்கு இணைப்புகள் உள்ளன, அவை தொடர்புடைய தலைப்புகளை உள்ளடக்கியவை.
+## ஒவ்வொரு பாடத்திலும் உள்ளது
+* முன்னோட்டப் பொருள்
+* செயல்படுத்தக்கூடிய Jupyter நோட்டுபுக், இது பெரும்பாலும் கட்டமைப்புக்கு குறிப்படையாக இருக்கும் (**PyTorch** அல்லது **TensorFlow**). செயல்படுத்தக்கூடிய நோட்டுபுக் வளர்ச்சியியல் பொருள்களையும் மிகுந்த அளவில் கொண்டுள்ளது, ஆகையால் பொருளை புரிந்து கொள்ள குறைந்தது ஒரு பதிப்பு நோட்டுபுக்கை (PyTorch அல்லத TensorFlow) படிக்க வேண்டும்.
+* சில தலைப்புகளுக்கு கிடைக்கும் **சேவில்கள்**, இவை நீங்கள் கற்றுக்கொண்ட பொருளை ஒரு குறிப்பிட்ட பிரச்சினையில் பயன்படுத்த முயல்வதற்கான வாய்ப்பாகும்.
+* சில பிரிவுகள் தொடர்புடைய தலைப்புகளை உள்ளடக்கும் [**MS Learn**](https://learn.microsoft.com/en-us/collections/7w28iy2xrqzdj0?WT.mc_id=academic-77998-bethanycheum) மாட்யூல்கள் இணைப்புகளை கொண்டுள்ளன.
 
-## துவக்கம்
+## தொடங்குதல்
 
-### 🎯 AI புதியவரா? இங்கே துவங்குங்கள்!
+### 🎯 AI யின் புதியவரா? இங்கே தொடங்கு!
 
-நீங்கள் முழுமையான AI புதியவராக இருந்தால் மற்றும் விரைவான, கைமுறையான உதாரணங்களை விரும்பினால், எங்கள் [**ஆரம்ப எளிய உதாரணங்கள்**](./examples/README.md) பார்க்கவும்! இவை அடங்கியுள்ளன:
+நீங்கள் முற்றிலும் AIவில் புதியவராக இருந்தால் மற்றும் விரைவாக, செயல்முறை உதாரணங்கள் வேண்டுமானால், எங்கள் [**ஆரம்பக்காரர்களுக்கான உதாரணங்கள்**](./examples/README.md) பார்த்துப் பாருங்கள்! இதில் உள்ளன:
 
-- 🌟 **வணக்கம் AI உலகம்** - உங்கள் முதல் AI திட்டம் (பேட்டர்ன் அடையாளம் கண்டறிதல்)
+- 🌟 **ஹலோ AI உலகம்** - உங்கள் முதல் AI நிகழ்ச்சி (பட்டர்ன் அடையாளம்)
 - 🧠 **எளிய நியூரல் நெட்வொர்க்** - ஆரம்பத்திலிருந்து நியூரல் நெட்வொர்க் கட்டமைக்கவும்  
-- 🖼️ **பட வகைப்பானி** - விவரமான கோமெண்ட்களுடன் படங்களை வகைப்படுத்தவும்
-- 💬 **உரை உணர்வு** - நேர்மறை/எறும்பு உரையை பகுப்பாய்வு செய்யவும்
+- 🖼️ **பட வகைபடுத்தி** - விரிவான கருத்துக்களுடன் படங்களை வகைப்படுத்தவும்
+- 💬 **உரை உணர்வு** - நேர்மறை/எதிர்மறை உரையை பகுப்பாய்வு செய்யவும்
 
-இந்த உதாரணங்கள் முழு பாடத்திட்டத்தில் குதிப்பது முன் AI கருத்துக்களைப் புரிந்துகொள்ள உதவுவதற்காக வடிவமைக்கப்பட்டுள்ளன.
+இந்த உதாரணங்கள் முழு பாடத்திட்டத்துக்குச் செல்லும் முன் AI கருத்துக்களை புரிந்துகொள்ள உதவியாக வடிவமைக்கப்பட்டுள்ளன.
 
-### 📚 முழு பாடத்திட்ட அமைப்பு
+### 📚 முழு பாடத்திட்ட அமைவு
 
-- உங்கள் மேம்பாட்டு சூழலை அமைக்க எங்களால் [அமைப்பு பாடம்](./lessons/0-course-setup/setup.md) உருவாக்கப்பட்டுள்ளது. - ஆசிரியர்களுக்கு, நாங்கள் [பாடத்திட்ட அமைப்பு பாடம்](./lessons/0-course-setup/for-teachers.md) உருவாக்கியுள்ளோம்!
-- [VSCode அல்லது Codespace இல் குறியீட்டை இயக்க](./lessons/0-course-setup/how-to-run.md) எப்படி
+- உங்கள் மேம்பாட்டு சூழலை அமைப்பதற்கு உதவும் ஒரு [அமைப்பு பாடம்](./lessons/0-course-setup/setup.md) எங்களால் உருவாக்கப்பட்டுள்ளது. - கல்வி நிபுணர்களுக்கு, ஒரு [பாடத்திட்ட அமைப்பு பாடம்](./lessons/0-course-setup/for-teachers.md) உங்களுக்காகவும் உருவாக்கப்பட்டுள்ளது!
+- VSCode அல்லது Codespaceல் [குறியீட்டைக் இயக்குவது எப்படி](./lessons/0-course-setup/how-to-run.md)
 
-இவை பின்பற்றவும்:
+இந்த படிகளை பின்பற்றுங்கள்:
 
-களஞ்சியத்தை கைப்பற்றவும்: இந்த பக்கத்தின் மேற்பக்க வலது மூலைவில் உள்ள "Fork" பொத்தானை கிளிக் செய்யவும்.
+கோப்பகம் கிளோன் செய்ய: இந்த பக்கத்தின் மேல் வலது மூலையில் உள்ள "Fork" பொத்தானை அழுத்தவும்.
 
-களஞ்சியத்தை கிளோன் செய்யவும்: `git clone https://github.com/microsoft/AI-For-Beginners.git`
+கோப்பகம் கிளோன் செய்யவும்: `git clone https://github.com/microsoft/AI-For-Beginners.git`
 
-பிறகு இந்த பக்கத்தின் நடுவில் உள்ள நட்சத்திரத்தை (🌟) மறக்காதீர்கள்.
+பின்னர் எளிதாக கண்டுபிடிக்க இந்த ரெப்போவை நட்சத்திரம் (🌟) விட மறக்கவாதீர்கள்.
 
-## பிற கற்றுநர்களை சந்திக்கவும்
+## பிற கற்றலாளர்களை சந்திக்கவும்
 
-இந்தப் பாடத்திட்டத்தை எடுத்துக் கொண்ட மற்ற கற்றுநர்களை சந்தித்து வலையமைப்பதற்கு எங்கள் [அங்கீகரிக்கப்பட்ட AI Discord சேவையகம்](https://aka.ms/genai-discord?WT.mc_id=academic-105485-bethanycheum) இணைந்திருங்கள்.
+இந்த பாடத்திட்டத்தை எடுத்துகொண்டு இருக்கிற மற்ற கற்றலாளர்களை சந்திக்க மற்றும் வலைப்பிணையம் அமைக்க எங்கள் [உத்தியோகபூர்வ AI Discord சேவையகம்](https://aka.ms/genai-discord?WT.mc_id=academic-105485-bethanycheum)யில் இணைக.
 
-உதவும் கருத்து அல்லது கேள்விகள் கொண்டிருந்தால் எங்கள் [Azure AI Foundry Developer Forum](https://aka.ms/foundry/forum) பார்வையிடவும்.
+உண்டான தயாரிப்பு கருத்துக்கள் அல்லது கேள்விகள் இருந்தால் எங்கள் [Azure AI Foundry Developer Forum](https://aka.ms/foundry/forum) உங்களுக்கு உதவும்.
 
-## குவிச்கள் 
+## வினாடி வினாக்கள்
 
-> **குவிச்களுக்கு குறிப்பு**: அனைத்து குவிச்களும் Quiz-app கோப்பகத்தில் உள்ளது (etc\quiz-app), அல்லது [ஆன்லைனில் இங்கே](https://ff-quizzes.netlify.app/) அவை பாடங்களில் இணைக்கப்பட்டுள்ளன, Quiz app உள்ளூர் முறையில் இயக்கலாம் அல்லது Azure-க்கு இடம் மாற்றலாம்; `quiz-app` கோப்பகத்தில் உள்ள அறிவுரைகளை பின்பற்றவும். அவை படுவதாக உள்ளூர் மொழிமாற்றம் செய்யப்படுகின்றன.
+> **வினாடி வினாக்கள் குறித்த குறிப்பு**: எல்லா வினாடி வினாக்களும் Quiz-app கோப்பகத்தில் etc\quiz-app உள்ளன, அல்லது [இங்கே ஆன்லைனில்](https://ff-quizzes.netlify.app/) காணப்படுகிறது. அவை பாடங்களில் இணைக்கப்பட்டுள்ளன. வினாடி வினா பயன்பாடு உள்ளூர் முறையில் இயக்கப்படலாம் அல்லது Azureக்கு பிரசரிக்கப்படலாம்; `quiz-app` கோப்பகத்தில் உள்ள வழிமுறைகளை பின்பற்றவும். அவை முன்னேற்றமாக உள்ளூர்மயமாக்கப்பட்டுள்ளன.
 
-## உதவிக்கான வேண்டுகோள்
+## உதவி தேவை
 
-உங்களிடம் யோசனைகள் உள்ளதா அல்லது எழுத்துப்பிழைகள் அல்லது குறியீடு பிழைகள் கண்டறிந்தீர்களா? ஒரு பிரச்சினையை எழுப்பவும் அல்லது தொகுப்பு கோரிக்கை உருவாக்கவும்.
+உங்களுக்கு ஏதேனும் பரிந்துரைகள் உள்ளதா அல்லது எழுத்துப்பிழைகள் அல்லது குறியீட்டு பிழைகள் கண்டெடுத்தீர்களா? ஒரு விதிமுறையோ அல்லது புல் கோரிக்கையோ உருவாக்கவும்.
 
 ## சிறப்பு நன்றி
 
 * **✍️ முதன்மை ஆசிரியர்:** [Dmitry Soshnikov](http://soshnikov.com), PhD
-* **🔥 ஆசிரியர்:** [Jen Looper](https://twitter.com/jenlooper), PhD
-* **🎨 ஸ்கெட்ச் நோட் வரைவாளர்:** [Tomomi Imura](https://twitter.com/girlie_mac)
-* **✅ குவுயிஸ் படைப்பாளர்:** [Lateefah Bello](https://github.com/CinnamonXI), [MLSA](https://studentambassadors.microsoft.com/)
-* **🙏 முக்கிய பங்கேற்பாளர்கள்:** [Evgenii Pishchik](https://github.com/Pe4enIks)
+* **🔥 தொகுப்பாளர்:** [Jen Looper](https://twitter.com/jenlooper), PhD
+* **🎨 ஸ்கெட்ச்நோட் வரைவாளர்:** [Tomomi Imura](https://twitter.com/girlie_mac)
+* **✅ வினாடி வினா உருவாக்குபவர்:** [Lateefah Bello](https://github.com/CinnamonXI), [MLSA](https://studentambassadors.microsoft.com/)
+* **🙏 முக்கிய பங்காளிகள்:** [Evgenii Pishchik](https://github.com/Pe4enIks)
 
-## பிற பாடத்திட்டங்களும்
+## பிற பாடத்திட்டங்கள்
 
 எங்கள் குழு பிற பாடத்திட்டங்களையும் உருவாக்குகிறது! பாருங்கள்:
 
@@ -217,17 +217,17 @@ _क्लाउड में AI_ विषयों के लिए एक क
 
 ## உதவி பெறுதல்
 
-AI செயலிகளை உருவாக்கும் போது ஏதாவது தடுமாறினால் அல்லது கேள்விகள் இருந்தால் MCP தொடர்பான கலந்துரையாடல்களில் கற்றுநர்கள் மற்றும் அனுபவ சமரசமாக்கலரும் கலந்து கொள்ளுங்கள். கேள்விகள் வரவேற்கப்படுகின்றன மற்றும் அறிவு சுதந்திரமாகப் பகிரப்படுகிறது.
+AI செயலிகளை உருவாக்கும்போது சிக்கலுக்கு ஆளாகிறீர்களா அல்லது கேள்விகள் உண்டா? MCP பற்றி விவாதிக்க மற்ற கற்றலாளர்களும் அனுபவமுள்ள மேம்படுத்துநர்களும் உள்ள சமூகத்தில் கலந்துகொள்ளுங்கள். இது கேள்விகள் வரவேற்கப்படும் மற்றும் அறிவு இலவசமாகப் பகிரப்படும் ஆதரவான சமுதாயமாகும்.
 
 [![Microsoft Foundry Discord](https://dcbadge.limes.pink/api/server/nTYy5BXMWG)](https://discord.gg/nTYy5BXMWG)
 
-தயாரிப்பு கருத்து அல்லது பிழைகள் இருந்தால் கீழ்க்காணும் இடத்தில் செல்லவும்:
+உண்டான தயாரிப்பு கருத்துக்கள் அல்லது பிழைகள் இருந்தால் பார்க்க:
 
 [![Microsoft Foundry Developer Forum](https://img.shields.io/badge/GitHub-Microsoft_Foundry_Developer_Forum-blue?style=for-the-badge&logo=github&color=000000&logoColor=fff)](https://aka.ms/foundry/forum)
 
 ---
 
 <!-- CO-OP TRANSLATOR DISCLAIMER START -->
-**கDisclaimer**:
-இந்த 문서는 AI மொழிபெயர்ப்பு சேவை [Co-op Translator](https://github.com/Azure/co-op-translator) பயன்படுத்தி மொழிபெயர்க்கப்பட்டுள்ளது. துருந்த மிகுமாற்றத்தை நோக்கி முயற்சிக்கின்றாலும், தானாக செய்யப்பட்ட மொழிபெயர்ப்புகளில் பிழைகள் அல்லது தவறுகள் இருக்க வாய்ப்பு உள்ளது. அசல் ஆவணம் அதன் சொந்த மொழியில் அதிகாரப்பூர்வ மூலமாக கருதப்பட வேண்டும். முக்கியமான தகவலுக்காக, தொழில்முறை மனித மொழிபெயர்ப்பை பரிந்துரைக்கிறோம். இந்த மொழிபெயர்ப்பின் பயன்பாட்டால் ஏற்பட்ட எந்த தவறுகள் அல்லது தவறான பொருள் புரிதலுக்கும் நாம் பொறுப்புக் கொள்ளமாட்டோம்.
+**குறிப்பு**:
+இந்த ஆவணம் AI மொழிபெயர்ப்பு சேவை [Co-op Translator](https://github.com/Azure/co-op-translator) மூலம் மொழிபெயர்க்கப்பட்டுள்ளது. நாங்கள் சரியான மொழிபெயர்ப்பிற்காக முயற்சித்தாலும், தானாக மேற்கொள்ளப்பட்ட மொழிபெயர்ப்புகளில் பிழைகள் அல்லது தவறுகள் இருக்க வாய்ப்பு உள்ளது. மூல ஆவணம் அதன் சொந்த மொழியில் அதிகாரப்பூர்வமான ஆதாரமாக கருதப்பட வேண்டும். முக்கியமான தகவல்களுக்கு, தொழில்முறை மனித மொழிபெயர்ப்பை பரிந்துரைக்கிறோம். இந்த மொழிபெயர்ப்பின் மூலம் ஏற்பட்ட எந்தவொரு தவறுபாடுகளுக்கும் அல்லது தவறான பொருள் புரிதலுக்கும் நாங்கள் பொறுப்பு ஏற்க மாட்டோம்.
 <!-- CO-OP TRANSLATOR DISCLAIMER END -->


### PR DESCRIPTION
Fixes #706. This restores the Tamil-language README under translations/ta/README.md while preserving the repository's translation layout. Validation: 102 lines contain Tamil script, 0 lines contain Devanagari characters, and git diff --check passes. No lesson logic or generated artifacts were changed.