### PR TITLE
docs: add serve:node17+ script shortcut to quizzes-app

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e20842fa-95ce-4bdd-80b2-4d1cee2f04ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  main\u001b[m\n",
+      "* \u001b[32mmy-learning-journey\u001b[m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!git branch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58d50c9f-84d3-4999-a805-951a756e4a42",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/etc/quiz-app/package.json
+++ b/etc/quiz-app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
+    "serve:node17+": "npx --node-options=\"--openssl-legacy-provider\" vue-cli-service serve --skip-plugins eslint",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },


### PR DESCRIPTION
This script bypasses legacy OpenSSL and ESLint compilation errors for developers running the quiz app on newer Node.js versions (v17+).
