### PR TITLE
fix: support quizzes with variable question counts

### DIFF
--- a/etc/quiz-app/src/components/Quiz.vue
+++ b/etc/quiz-app/src/components/Quiz.vue
@@ -21,7 +21,7 @@
                 :key="index"
                 v-for="(option, index) in quiz.quiz[currentQuestion]
                   .answerOptions"
-                @click="handleAnswerClick(option.isCorrect)"
+                @click="handleAnswerClick(option.isCorrect, quiz.quiz.length)"
                 class="btn ans-btn"
               >
                 {{ option.answerText }}
@@ -62,12 +62,11 @@ export default {
   },
 
   methods: {
-    handleAnswerClick(isCorrect) {
+    handleAnswerClick(isCorrect, questionCount) {
       this.error = false;
       let nextQuestion = this.currentQuestion + 1;
       if (isCorrect) {
-        //always 3 questions per quiz
-        if (nextQuestion < 3) {
+        if (nextQuestion < questionCount) {
           this.currentQuestion = nextQuestion;
         } else {
           this.complete = true;


### PR DESCRIPTION
## Summary

- use the active quiz's question count to decide when to complete
- keep existing three-question quizzes unchanged while allowing quiz 224's fourth question to appear

## Problem

The lesson 24 post-quiz contains four questions, but `Quiz.vue` marks it complete after three correct answers. As a result, learners never see the final model-fairness question.

## Validation

- Ran: `npm ci`
- Ran: `npx eslint src/components/Quiz.vue --rule "vue/multi-word-component-names: off"`
- Ran: `npm run build -- --skip-plugins @vue/cli-plugin-eslint --dest ../../../../validation-output/ai-beginners-quiz-build-pr733`
- Checked: the updated handler advances to question 4 and completes after it; three-question quizzes still complete after question 3