### PR TITLE
Fix broken Word Embeddings link in NLP lesson README (all translations)

### DIFF
--- a/lessons/5-NLP/README.md
+++ b/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ If you're interested in learning about NLP from a classic ML perspective, visit 
 In this section we will learn about:
 
 * [Representing text as tensors](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Language Modeling](15-LanguageModeling/README.md)
 * [Recurrent Neural Networks](16-RNN/README.md)
 * [Generative Networks](17-GenerativeNetworks/README.md)

--- a/translations/ar/lessons/5-NLP/README.md
+++ b/translations/ar/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 في هذا القسم سنتعلم عن:
 
 * [تمثيل النصوص كمصفوفات](13-TextRep/README.md)
-* [تضمين الكلمات](14-Emdeddings/README.md)
+* [تضمين الكلمات](14-Embeddings/README.md)
 * [نمذجة اللغة](15-LanguageModeling/README.md)
 * [الشبكات العصبية العودية](16-RNN/README.md)
 * [الشبكات التوليدية](17-GenerativeNetworks/README.md)

--- a/translations/bg/lessons/5-NLP/README.md
+++ b/translations/bg/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 В този раздел ще научим за:
 
 * [Представяне на текст като тензори](13-TextRep/README.md)
-* [Векторни представяния на думи (Word Embeddings)](14-Emdeddings/README.md)
+* [Векторни представяния на думи (Word Embeddings)](14-Embeddings/README.md)
 * [Моделиране на езика](15-LanguageModeling/README.md)
 * [Рекурентни невронни мрежи](16-RNN/README.md)
 * [Генеративни мрежи](17-GenerativeNetworks/README.md)

--- a/translations/bn/lessons/5-NLP/README.md
+++ b/translations/bn/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 এই অংশে আমরা শিখব:
 
 * [টেক্সটকে টেনসর হিসেবে উপস্থাপন](13-TextRep/README.md)
-* [ওয়ার্ড এম্বেডিংস](14-Emdeddings/README.md)
+* [ওয়ার্ড এম্বেডিংস](14-Embeddings/README.md)
 * [ভাষা মডেলিং](15-LanguageModeling/README.md)
 * [রিকারেন্ট নিউরাল নেটওয়ার্ক](16-RNN/README.md)
 * [জেনারেটিভ নেটওয়ার্ক](17-GenerativeNetworks/README.md)

--- a/translations/cs/lessons/5-NLP/README.md
+++ b/translations/cs/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Pokud máte zájem učit se o NLP z klasické perspektivy strojového učení, n
 V této sekci se naučíme o:
 
 * [Reprezentaci textu jako tenzorů](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Jazykovém modelování](15-LanguageModeling/README.md)
 * [Rekurentních neuronových sítích](16-RNN/README.md)
 * [Generativních sítích](17-GenerativeNetworks/README.md)

--- a/translations/da/lessons/5-NLP/README.md
+++ b/translations/da/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Hvis du er interesseret i at lære om NLP fra et klassisk ML-perspektiv, besøg 
 I denne sektion vil vi lære om:
 
 * [At repræsentere tekst som tensors](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Sprogsmodellering](15-LanguageModeling/README.md)
 * [Recurrent Neural Networks](16-RNN/README.md)
 * [Generative Networks](17-GenerativeNetworks/README.md)

--- a/translations/de/lessons/5-NLP/README.md
+++ b/translations/de/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Wenn Sie NLP aus einer klassischen ML-Perspektive kennenlernen möchten, besuche
 In diesem Abschnitt lernen wir:
 
 * [Text als Tensoren darstellen](13-TextRep/README.md)
-* [Wort-Einbettungen](14-Emdeddings/README.md)
+* [Wort-Einbettungen](14-Embeddings/README.md)
 * [Sprachmodellierung](15-LanguageModeling/README.md)
 * [Rekurrente neuronale Netze](16-RNN/README.md)
 * [Generative Netzwerke](17-GenerativeNetworks/README.md)

--- a/translations/el/lessons/5-NLP/README.md
+++ b/translations/el/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 Σε αυτήν την ενότητα θα μάθουμε για:
 
 * [Αναπαράσταση κειμένου ως τάνσορες](13-TextRep/README.md)
-* [Ενσωματώσεις λέξεων](14-Emdeddings/README.md)
+* [Ενσωματώσεις λέξεων](14-Embeddings/README.md)
 * [Μοντελοποίηση γλώσσας](15-LanguageModeling/README.md)
 * [Επαναλαμβανόμενα νευρωνικά δίκτυα](16-RNN/README.md)
 * [Γενετικά δίκτυα](17-GenerativeNetworks/README.md)

--- a/translations/en/lessons/5-NLP/README.md
+++ b/translations/en/lessons/5-NLP/README.md
@@ -68,7 +68,7 @@ If you're interested in learning NLP from a traditional machine learning perspec
 In this section, we will cover:
 
 * [Representing text as tensors](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Language Modeling](15-LanguageModeling/README.md)
 * [Recurrent Neural Networks](16-RNN/README.md)
 * [Generative Networks](17-GenerativeNetworks/README.md)

--- a/translations/es/lessons/5-NLP/README.md
+++ b/translations/es/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Si te interesa aprender sobre PLN desde una perspectiva clásica de ML, visita [
 En esta sección aprenderemos sobre:
 
 * [Representar texto como tensores](13-TextRep/README.md)
-* [Representaciones de palabras (Word Embeddings)](14-Emdeddings/README.md)
+* [Representaciones de palabras (Word Embeddings)](14-Embeddings/README.md)
 * [Modelado de lenguaje](15-LanguageModeling/README.md)
 * [Redes neuronales recurrentes](16-RNN/README.md)
 * [Redes generativas](17-GenerativeNetworks/README.md)

--- a/translations/et/lessons/5-NLP/README.md
+++ b/translations/et/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Kui soovite õppida NLP-d klassikalisest masinõppe vaatenurgast, vaadake [seda 
 Selles peatükis õpime:
 
 * [Teksti esitamine tensoritena](13-TextRep/README.md)
-* [Sõnade embedid](14-Emdeddings/README.md)
+* [Sõnade embedid](14-Embeddings/README.md)
 * [Keelemudelid](15-LanguageModeling/README.md)
 * [Rekursiivsed närvivõrgud](16-RNN/README.md)
 * [Generatiivvõrgud](17-GenerativeNetworks/README.md)

--- a/translations/fa/lessons/5-NLP/README.md
+++ b/translations/fa/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 در این بخش درباره موارد زیر خواهیم آموخت:
 
 * [نمایش متن به صورت تنسورها](13-TextRep/README.md)
-* [توکارگذاری کلمات](14-Emdeddings/README.md)
+* [توکارگذاری کلمات](14-Embeddings/README.md)
 * [مدلسازی زبان](15-LanguageModeling/README.md)
 * [شبکه‌های عصبی بازگشتی](16-RNN/README.md)
 * [شبکه‌های مولد](17-GenerativeNetworks/README.md)

--- a/translations/fi/lessons/5-NLP/README.md
+++ b/translations/fi/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Jos olet kiinnostunut oppimaan NLP:tä klassisesta koneoppimisen näkökulmasta,
 Tässä osiossa opimme:
 
 * [Tekstin esittäminen tensoreina](13-TextRep/README.md)
-* [Sanasijoitukset](14-Emdeddings/README.md)
+* [Sanasijoitukset](14-Embeddings/README.md)
 * [Kielimallit](15-LanguageModeling/README.md)
 * [Toistuvat hermoverkot](16-RNN/README.md)
 * [Generatiiviset verkot](17-GenerativeNetworks/README.md)

--- a/translations/fr/lessons/5-NLP/README.md
+++ b/translations/fr/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Si vous souhaitez apprendre le TLN d’un point de vue classique du ML, visitez 
 Dans cette section, nous apprendrons à propos de :
 
 * [Représentation du texte sous forme de tenseurs](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Modélisation du langage](15-LanguageModeling/README.md)
 * [Réseaux de neurones récurrents](16-RNN/README.md)
 * [Réseaux génératifs](17-GenerativeNetworks/README.md)

--- a/translations/he/lessons/5-NLP/README.md
+++ b/translations/he/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 בחלק זה נלמד על:
 
 * [ייצוג טקסט כמטריצות](13-TextRep/README.md)
-* [הנחת מילים](14-Emdeddings/README.md)
+* [הנחת מילים](14-Embeddings/README.md)
 * [מודלינג שפה](15-LanguageModeling/README.md)
 * [רשתות עצביות חוזרות](16-RNN/README.md)
 * [רשתות גנרטיביות](17-GenerativeNetworks/README.md)

--- a/translations/hi/lessons/5-NLP/README.md
+++ b/translations/hi/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 इस खंड में हम निम्नलिखित के बारे में सीखेंगे:
 
 * [टेक्स्ट को टेंसर के रूप में प्रस्तुत करना](13-TextRep/README.md)
-* [वर्ड एम्बेडिंग्स](14-Emdeddings/README.md)
+* [वर्ड एम्बेडिंग्स](14-Embeddings/README.md)
 * [भाषा मॉडलिंग](15-LanguageModeling/README.md)
 * [पुनरावर्ती न्यूरल नेटवर्क](16-RNN/README.md)
 * [जनरेटिव नेटवर्क](17-GenerativeNetworks/README.md)

--- a/translations/hr/lessons/5-NLP/README.md
+++ b/translations/hr/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Ako ste zainteresirani za učenje o NLP-u iz klasične perspektive strojnog uče
 U ovom odjeljku naučit ćemo o:
 
 * [Predstavljanje teksta kao tenzora](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Modeliranje jezika](15-LanguageModeling/README.md)
 * [Rekurentne neuronske mreže](16-RNN/README.md)
 * [Generativne mreže](17-GenerativeNetworks/README.md)

--- a/translations/hu/lessons/5-NLP/README.md
+++ b/translations/hu/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Ha érdekel az NLP klasszikus gépi tanulási nézőpontból, látogasd meg [ezt
 Ebben a szakaszban az alábbiakat tanuljuk meg:
 
 * [Szöveg reprezentálása tenzorokként](13-TextRep/README.md)
-* [Szóbeágyazások](14-Emdeddings/README.md)
+* [Szóbeágyazások](14-Embeddings/README.md)
 * [Nyelvmodellezés](15-LanguageModeling/README.md)
 * [Rekurzív neurális hálózatok](16-RNN/README.md)
 * [Generatív hálózatok](17-GenerativeNetworks/README.md)

--- a/translations/id/lessons/5-NLP/README.md
+++ b/translations/id/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Jika Anda tertarik belajar NLP dari perspektif ML klasik, kunjungi [rangkaian pe
 Dalam bagian ini kita akan mempelajari tentang:
 
 * [Merepresentasikan teks sebagai tensor](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Pemodelan Bahasa](15-LanguageModeling/README.md)
 * [Jaringan Saraf Berulang](16-RNN/README.md)
 * [Jaringan Generatif](17-GenerativeNetworks/README.md)

--- a/translations/it/lessons/5-NLP/README.md
+++ b/translations/it/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Se sei interessato a imparare NLP da una prospettiva classica di ML, visita [que
 In questa sezione impareremo:
 
 * [Rappresentare il testo come tensori](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Modellazione del linguaggio](15-LanguageModeling/README.md)
 * [Reti Neurali Ricorrenti](16-RNN/README.md)
 * [Reti generative](17-GenerativeNetworks/README.md)

--- a/translations/ja/lessons/5-NLP/README.md
+++ b/translations/ja/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 このセクションでは以下のことを学びます：
 
 * [テキストをテンソルとして表現する](13-TextRep/README.md)
-* [単語埋め込み](14-Emdeddings/README.md)
+* [単語埋め込み](14-Embeddings/README.md)
 * [言語モデル](15-LanguageModeling/README.md)
 * [リカレントニューラルネットワーク](16-RNN/README.md)
 * [生成モデル](17-GenerativeNetworks/README.md)

--- a/translations/km/lessons/5-NLP/README.md
+++ b/translations/km/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 នៅក្នុងផ្នែកនេះ យើងនឹងរៀនពី៖
 
 * [កំណត់តំណាងអត្ថបទជាតង់ស័រ](13-TextRep/README.md)
-* [ការបញ្ចូលពាក្យ](14-Emdeddings/README.md)
+* [ការបញ្ចូលពាក្យ](14-Embeddings/README.md)
 * [ការម៉ូដែលភាសា](15-LanguageModeling/README.md)
 * [បណ្ដាញអាចប្រើឡើងវិញ](16-RNN/README.md)
 * [បណ្ដាញបង្កើត](17-GenerativeNetworks/README.md)

--- a/translations/kn/lessons/5-NLP/README.md
+++ b/translations/kn/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 ಈ ವಿಭಾಗದಲ್ಲಿ ನಾವು ಕಲಿಯಲಿರುವುದು:
 
 * [ಪಠ್ಯವನ್ನು ಟೆನ್ಸರ್‌ಗಳಾಗಿ ಪ್ರತಿನಿಧಿಸುವಿಕೆ](13-TextRep/README.md)
-* [ಪದ embeddings](14-Emdeddings/README.md)
+* [ಪದ embeddings](14-Embeddings/README.md)
 * [ಭಾಷಾ ಮಾದರಿಕರಣ](15-LanguageModeling/README.md)
 * [ಪುನರಾವೃತ್ತ ನ್ಯೂರಲ್ ನೆಟ್‌ವರ್ಕ್‌ಗಳು](16-RNN/README.md)
 * [ಸೃಜನಾತ್ಮಕ ಜಾಲಗಳು](17-GenerativeNetworks/README.md)

--- a/translations/ko/lessons/5-NLP/README.md
+++ b/translations/ko/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 이 섹션에서는 다음 내용을 배울 것입니다:  
 
 * [텍스트를 텐서로 표현하기](13-TextRep/README.md)  
-* [단어 임베딩](14-Emdeddings/README.md)  
+* [단어 임베딩](14-Embeddings/README.md)  
 * [언어 모델링](15-LanguageModeling/README.md)  
 * [순환 신경망](16-RNN/README.md)  
 * [생성 네트워크](17-GenerativeNetworks/README.md)  

--- a/translations/lt/lessons/5-NLP/README.md
+++ b/translations/lt/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Jei jus domina NLP mokymasis iš klasikinio ML požiūrio, apsilankykite [šiame
 Šioje dalyje mes sužinosime apie:
 
 * [Teksto vaizdavimą tensoriais](13-TextRep/README.md)
-* [Žodžių įterpimus](14-Emdeddings/README.md)
+* [Žodžių įterpimus](14-Embeddings/README.md)
 * [Kalbos modeliavimą](15-LanguageModeling/README.md)
 * [Rekursinius neuroninius tinklus](16-RNN/README.md)
 * [Generatyvinius tinklus](17-GenerativeNetworks/README.md)

--- a/translations/ml/lessons/5-NLP/README.md
+++ b/translations/ml/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 ഈ വിഭാഗത്തിൽ നാം പഠിക്കാനിരിക്കുന്നത്:
 
 * [ടെക്സ്റ്റ് ടെൻസറുകളായി പ്രതിപാദിക്കൽ](13-TextRep/README.md)
-* [വാക്ക് എംബെഡ്ഡിംഗ്സ്](14-Emdeddings/README.md)
+* [വാക്ക് എംബെഡ്ഡിംഗ്സ്](14-Embeddings/README.md)
 * [ഭാഷാ മോഡലിംഗ്](15-LanguageModeling/README.md)
 * [റികറന്റ് ന്യൂറൽ നെറ്റ്വർക്‌സ്](16-RNN/README.md)
 * [ജനറേറ്റീവ് നെറ്റ്‌വർക്കുകൾ](17-GenerativeNetworks/README.md)

--- a/translations/mr/lessons/5-NLP/README.md
+++ b/translations/mr/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 या विभागात आपण खालील गोष्टी शिकणार आहोत:
 
 * [मजकूराचे टेन्सर स्वरूप](13-TextRep/README.md)
-* [शब्द एम्बेडिंग्ज](14-Emdeddings/README.md)
+* [शब्द एम्बेडिंग्ज](14-Embeddings/README.md)
 * [भाषा मॉडेलिंग](15-LanguageModeling/README.md)
 * [पुनरावर्ती न्यूरल नेटवर्क्स](16-RNN/README.md)
 * [जनरेटिव्ह नेटवर्क्स](17-GenerativeNetworks/README.md)

--- a/translations/ms/lessons/5-NLP/README.md
+++ b/translations/ms/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Jika anda berminat untuk belajar tentang NLP dari perspektif ML klasik, lawati [
 Dalam bahagian ini kita akan belajar tentang:
 
 * [Mewakili teks sebagai tensor](13-TextRep/README.md)
-* [Penggantungan Perkataan](14-Emdeddings/README.md)
+* [Penggantungan Perkataan](14-Embeddings/README.md)
 * [Pemodelan Bahasa](15-LanguageModeling/README.md)
 * [Rangkaian Neural Berulang](16-RNN/README.md)
 * [Rangkaian Generatif](17-GenerativeNetworks/README.md)

--- a/translations/my/lessons/5-NLP/README.md
+++ b/translations/my/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 ဒီအပိုင်းမှာ ကျွန်တော်တို့ သင်ကြားသွားမယ့် အကြောင်းများမှာ -
 
 * [စာသားကို tensor အဖြစ် ကိုယ်စားပြုခြင်း](13-TextRep/README.md)
-* [စကားလုံးထည့်သွင်းခြင်း](14-Emdeddings/README.md)
+* [စကားလုံးထည့်သွင်းခြင်း](14-Embeddings/README.md)
 * [ဘာသာစကားပုံစံဖန်တီးခြင်း](15-LanguageModeling/README.md)
 * [ကျန်ကြွယ်လာသော နယူးရယ်နက်ရွက်များ](16-RNN/README.md)
 * [ဖန်တီးရေးကွန်ယက်များ](17-GenerativeNetworks/README.md)

--- a/translations/ne/lessons/5-NLP/README.md
+++ b/translations/ne/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 यस खण्डमा हामी सिक्नेछौं:
 
 * [टेक्स्टलाई टेन्सरको रूपमा प्रतिनिधित्व गर्दै](13-TextRep/README.md)
-* [शब्द एम्बेडिङहरू](14-Emdeddings/README.md)
+* [शब्द एम्बेडिङहरू](14-Embeddings/README.md)
 * [भाषा मोडेलिङ](15-LanguageModeling/README.md)
 * [पुनरावृत्त न्यूरल नेटवर्कहरू](16-RNN/README.md)
 * [जनरेटिभ नेटवर्कहरू](17-GenerativeNetworks/README.md)

--- a/translations/nl/lessons/5-NLP/README.md
+++ b/translations/nl/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Als je geïnteresseerd bent in NLP leren vanuit een klassiek ML-perspectief, bez
 In deze sectie leren we over:
 
 * [Tekst representeren als tensors](13-TextRep/README.md)
-* [Woorden-embedding](14-Emdeddings/README.md)
+* [Woorden-embedding](14-Embeddings/README.md)
 * [Taalmodellering](15-LanguageModeling/README.md)
 * [Recurrente neurale netwerken](16-RNN/README.md)
 * [Generatieve netwerken](17-GenerativeNetworks/README.md)

--- a/translations/no/lessons/5-NLP/README.md
+++ b/translations/no/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Hvis du er interessert i å lære om NLP fra et klassisk ML-perspektiv, besøk [
 I denne seksjonen skal vi lære om:
 
 * [Representasjon av tekst som tensorer](13-TextRep/README.md)
-* [Ordinnstikk](14-Emdeddings/README.md)
+* [Ordinnstikk](14-Embeddings/README.md)
 * [Språkmodellering](15-LanguageModeling/README.md)
 * [Rekurrente nevrale nettverk](16-RNN/README.md)
 * [Generative nettverk](17-GenerativeNetworks/README.md)

--- a/translations/pa/lessons/5-NLP/README.md
+++ b/translations/pa/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 ਇਸ ਭਾਗ ਵਿੱਚ ਅਸੀਂ ਸਿਖਾਂਗੇ:
 
 * [ਟੈਕਸਟ ਨੂੰ ਟੈਂਸਰ ਵਜੋਂ ਪ੍ਰਤੀਨਿਧਿਤ ਕਰਨਾ](13-TextRep/README.md)
-* [ਸ਼ਬਦ ਐਂਬੈੱਡਿੰਗਜ਼](14-Emdeddings/README.md)
+* [ਸ਼ਬਦ ਐਂਬੈੱਡਿੰਗਜ਼](14-Embeddings/README.md)
 * [ਭਾਸ਼ਾ ਮਾਡਲਿੰਗ](15-LanguageModeling/README.md)
 * [ਰਿਕਰਨਟ ਨਿਊਰਲ ਨੈੱਟਵਰਕ](16-RNN/README.md)
 * [ਜਨਰੇਟਿਵ ਨੈੱਟਵਰਕ](17-GenerativeNetworks/README.md)

--- a/translations/pcm/lessons/5-NLP/README.md
+++ b/translations/pcm/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ If you want learn NLP from classic ML side, check [this suite of lessons](https:
 For this section, we go learn about:
 
 * [How to represent text as tensors](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Language Modeling](15-LanguageModeling/README.md)
 * [Recurrent Neural Networks](16-RNN/README.md)
 * [Generative Networks](17-GenerativeNetworks/README.md)

--- a/translations/pl/lessons/5-NLP/README.md
+++ b/translations/pl/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Jeśli chcesz nauczyć się NLP z klasycznej perspektywy ML, odwiedź [tę seri�
 W tej sekcji nauczymy się o:
 
 * [Reprezentowaniu tekstu jako tensory](13-TextRep/README.md)
-* [Osadzaniu słów (Word Embeddings)](14-Emdeddings/README.md)
+* [Osadzaniu słów (Word Embeddings)](14-Embeddings/README.md)
 * [Modelowaniu języka](15-LanguageModeling/README.md)
 * [Rekurencyjnych sieciach neuronowych](16-RNN/README.md)
 * [Sieciach generatywnych](17-GenerativeNetworks/README.md)

--- a/translations/pt-BR/lessons/5-NLP/README.md
+++ b/translations/pt-BR/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Se você tem interesse em aprender sobre PLN a partir de uma perspectiva clássi
 Nesta seção vamos aprender sobre:
 
 * [Representando texto como tensores](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Modelagem de Linguagem](15-LanguageModeling/README.md)
 * [Redes Neurais Recorrentes](16-RNN/README.md)
 * [Redes Generativas](17-GenerativeNetworks/README.md)

--- a/translations/pt-PT/lessons/5-NLP/README.md
+++ b/translations/pt-PT/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Se estiver interessado em aprender sobre PLN a partir de uma perspetiva clássic
 Nesta secção vamos aprender sobre:
 
 * [Representar texto como tensores](13-TextRep/README.md)
-* [Word Embeddings (Incorporação de Palavras)](14-Emdeddings/README.md)
+* [Word Embeddings (Incorporação de Palavras)](14-Embeddings/README.md)
 * [Modelação de Linguagem](15-LanguageModeling/README.md)
 * [Redes Neurais Recorrentes](16-RNN/README.md)
 * [Redes Generativas](17-GenerativeNetworks/README.md)

--- a/translations/ro/lessons/5-NLP/README.md
+++ b/translations/ro/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Dacă ești interesat să înveți despre NLP dintr-o perspectivă clasică ML, 
 În această secțiune vom învăța despre:
 
 * [Reprezentarea textului ca tensori](13-TextRep/README.md)
-* [Cuvinte încorporate (Word Embeddings)](14-Emdeddings/README.md)
+* [Cuvinte încorporate (Word Embeddings)](14-Embeddings/README.md)
 * [Modelarea limbajului](15-LanguageModeling/README.md)
 * [Rețele neuronale recurente](16-RNN/README.md)
 * [Rețele generative](17-GenerativeNetworks/README.md)

--- a/translations/ru/lessons/5-NLP/README.md
+++ b/translations/ru/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 В этом разделе мы изучим:
 
 * [Представление текста в виде тензоров](13-TextRep/README.md)
-* [Встраивания слов](14-Emdeddings/README.md)
+* [Встраивания слов](14-Embeddings/README.md)
 * [Моделирование языка](15-LanguageModeling/README.md)
 * [Рекуррентные нейронные сети](16-RNN/README.md)
 * [Генеративные сети](17-GenerativeNetworks/README.md)

--- a/translations/sk/lessons/5-NLP/README.md
+++ b/translations/sk/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Ak vás zaujíma učenie NLP z klasickej perspektívy strojového učenia, navš
 V tejto sekcii sa naučíme:
 
 * [Reprezentácia textu ako tenzorov](13-TextRep/README.md)
-* [Vkladanie slov](14-Emdeddings/README.md)
+* [Vkladanie slov](14-Embeddings/README.md)
 * [Modelovanie jazyka](15-LanguageModeling/README.md)
 * [Rekurentné neurónové siete](16-RNN/README.md)
 * [Generatívne siete](17-GenerativeNetworks/README.md)

--- a/translations/sl/lessons/5-NLP/README.md
+++ b/translations/sl/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 V tem poglavju se bomo naučili o:
 
 * [Predstavljanje besedila kot tenzorji](13-TextRep/README.md)
-* [Vgradnje besed (Word Embeddings)](14-Emdeddings/README.md)
+* [Vgradnje besed (Word Embeddings)](14-Embeddings/README.md)
 * [Jezikovno modeliranje](15-LanguageModeling/README.md)
 * [Rekurentne nevronske mreže](16-RNN/README.md)
 * [Generativne mreže](17-GenerativeNetworks/README.md)

--- a/translations/sr/lessons/5-NLP/README.md
+++ b/translations/sr/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 У овом одељку ћемо научити о:
 
 * [Представљање текста као тензора](13-TextRep/README.md)
-* [Уградње речи](14-Emdeddings/README.md)
+* [Уградње речи](14-Embeddings/README.md)
 * [Језички модели](15-LanguageModeling/README.md)
 * [Рекурентне неуронске мреже](16-RNN/README.md)
 * [Генеративне мреже](17-GenerativeNetworks/README.md)

--- a/translations/sv/lessons/5-NLP/README.md
+++ b/translations/sv/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Om du är intresserad av att lära dig om NLP från ett klassiskt ML-perspektiv,
 I detta avsnitt kommer vi att lära oss om:
 
 * [Att representera text som tensorer](13-TextRep/README.md)
-* [Ordbäddningar](14-Emdeddings/README.md)
+* [Ordbäddningar](14-Embeddings/README.md)
 * [Språkmodellering](15-LanguageModeling/README.md)
 * [Rekurrenta neurala nätverk](16-RNN/README.md)
 * [Generativa nätverk](17-GenerativeNetworks/README.md)

--- a/translations/sw/lessons/5-NLP/README.md
+++ b/translations/sw/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Ikiwa unavutiwa na kujifunza kuhusu NLP kutoka kwa mtazamo wa ML wa jadi, tembel
 Katika sehemu hii tutajifunza kuhusu:
 
 * [Kuonyesha maandishi kama tensors](13-TextRep/README.md)
-* [Uingiliano wa Maneno](14-Emdeddings/README.md)
+* [Uingiliano wa Maneno](14-Embeddings/README.md)
 * [Mifano ya Lugha](15-LanguageModeling/README.md)
 * [Mitandao ya Neva Inayorudia](16-RNN/README.md)
 * [Mitandao Inazozalisha](17-GenerativeNetworks/README.md)

--- a/translations/ta/lessons/5-NLP/README.md
+++ b/translations/ta/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 இந்தப் பிரிவில் நாங்கள் கற்கப்போகும் விஷயங்கள்:
 
 * [உரை துணைப்பொருள்களாக (tensors) பிரதிநிதிக்கும்](13-TextRep/README.md)
-* [வார்த்தை கையிருப்புக்கள்](14-Emdeddings/README.md)
+* [வார்த்தை கையிருப்புக்கள்](14-Embeddings/README.md)
 * [மொழிமுறை மாதிரிப்பாக்கம்](15-LanguageModeling/README.md)
 * [திரும்பி செயல்படும் நியூரல் நெட்வொர்க்குகள்](16-RNN/README.md)
 * [உருவாக்கும் நெட்வொர்க்குகள்](17-GenerativeNetworks/README.md)

--- a/translations/te/lessons/5-NLP/README.md
+++ b/translations/te/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 ఈ భాగంలో మనం నేర్చుకునేది:
 
 * [పదాలను టెన్సర్స్ రూపంలో ప్రాతినిధ్యం](13-TextRep/README.md)
-* [వర్డ్ ఎంబెడ్డింగ్స్](14-Emdeddings/README.md)
+* [వర్డ్ ఎంబెడ్డింగ్స్](14-Embeddings/README.md)
 * [భాషా మోడలింగ్](15-LanguageModeling/README.md)
 * [రికరెంట్ న్యూరల్ నెట్‌వర్క్స్](16-RNN/README.md)
 * [జనరేటివ్ నెట్‌వర్క్స్](17-GenerativeNetworks/README.md)

--- a/translations/th/lessons/5-NLP/README.md
+++ b/translations/th/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 ในส่วนนี้เราจะเรียนรู้เกี่ยวกับ:
 
 * [การแทนข้อความเป็นเทนเซอร์](13-TextRep/README.md)
-* [การฝังคำ](14-Emdeddings/README.md)
+* [การฝังคำ](14-Embeddings/README.md)
 * [การทำแบบจำลองภาษา](15-LanguageModeling/README.md)
 * [โครงข่ายประสาทเทียมวนซ้ำ](16-RNN/README.md)
 * [โครงข่ายสร้างสรรค์](17-GenerativeNetworks/README.md)

--- a/translations/tl/lessons/5-NLP/README.md
+++ b/translations/tl/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Kung interesado kang matuto tungkol sa NLP mula sa klasikal na pananaw ng ML, bi
 Sa seksyong ito ay matututuhan natin ang tungkol sa:
 
 * [Pagre-representa ng teksto bilang mga tensor](13-TextRep/README.md)
-* [Mga Word Embeddings](14-Emdeddings/README.md)
+* [Mga Word Embeddings](14-Embeddings/README.md)
 * [Pagmomodelo ng Wika](15-LanguageModeling/README.md)
 * [Mga Recurrent Neural Network](16-RNN/README.md)
 * [Mga Generative Network](17-GenerativeNetworks/README.md)

--- a/translations/tr/lessons/5-NLP/README.md
+++ b/translations/tr/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Klasik ML bakış açısından NLP öğrenmek isterseniz, [bu ders setini](https
 Bu bölümde şunları öğreneceğiz:
 
 * [Metni tensörler olarak temsil etme](13-TextRep/README.md)
-* [Kelime Gömme](14-Emdeddings/README.md)
+* [Kelime Gömme](14-Embeddings/README.md)
 * [Dil Modellemesi](15-LanguageModeling/README.md)
 * [Geri Dönüşümlü Sinir Ağları](16-RNN/README.md)
 * [Üretici Ağlar](17-GenerativeNetworks/README.md)

--- a/translations/uk/lessons/5-NLP/README.md
+++ b/translations/uk/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 У цьому розділі ми вивчимо:
 
 * [Подання тексту у вигляді тензорів](13-TextRep/README.md)
-* [Векторне подання слів (Word Embeddings)](14-Emdeddings/README.md)
+* [Векторне подання слів (Word Embeddings)](14-Embeddings/README.md)
 * [Моделювання мови](15-LanguageModeling/README.md)
 * [Рекурентні нейронні мережі](16-RNN/README.md)
 * [Генеративні мережі](17-GenerativeNetworks/README.md)

--- a/translations/ur/lessons/5-NLP/README.md
+++ b/translations/ur/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 اس سیکشن میں ہم سیکھیں گے:
 
 * [متن کو ٹینسرز کے طور پر پیش کرنا](13-TextRep/README.md)
-* [ورڈ ایمبیڈنگز](14-Emdeddings/README.md)
+* [ورڈ ایمبیڈنگز](14-Embeddings/README.md)
 * [لینگویج ماڈلنگ](15-LanguageModeling/README.md)
 * [ریکرنٹ نیورل نیٹ ورکس](16-RNN/README.md)
 * [جنریٹو نیٹ ورکس](17-GenerativeNetworks/README.md)

--- a/translations/vi/lessons/5-NLP/README.md
+++ b/translations/vi/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ Nếu bạn quan tâm đến việc học NLP từ góc nhìn ML cổ điển, h
 Trong phần này chúng ta sẽ học về:
 
 * [Biểu diễn văn bản dưới dạng tensor](13-TextRep/README.md)
-* [Word Embeddings](14-Emdeddings/README.md)
+* [Word Embeddings](14-Embeddings/README.md)
 * [Mô hình Ngôn ngữ](15-LanguageModeling/README.md)
 * [Mạng Nơ-ron Hồi tiếp](16-RNN/README.md)
 * [Mạng Sinh tạo](17-GenerativeNetworks/README.md)

--- a/translations/zh-CN/lessons/5-NLP/README.md
+++ b/translations/zh-CN/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 本节我们将学习：
 
 * [将文本表示为张量](13-TextRep/README.md)
-* [词嵌入](14-Emdeddings/README.md)
+* [词嵌入](14-Embeddings/README.md)
 * [语言模型](15-LanguageModeling/README.md)
 * [循环神经网络](16-RNN/README.md)
 * [生成网络](17-GenerativeNetworks/README.md)

--- a/translations/zh-HK/lessons/5-NLP/README.md
+++ b/translations/zh-HK/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 本節中我們將學習：
 
 * [將文本表示為張量](13-TextRep/README.md)
-* [詞嵌入](14-Emdeddings/README.md)
+* [詞嵌入](14-Embeddings/README.md)
 * [語言模型](15-LanguageModeling/README.md)
 * [循環神經網絡](16-RNN/README.md)
 * [生成網絡](17-GenerativeNetworks/README.md)

--- a/translations/zh-MO/lessons/5-NLP/README.md
+++ b/translations/zh-MO/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 在本節中，我們將學習：
 
 * [將文本表示為張量](13-TextRep/README.md)
-* [詞嵌入](14-Emdeddings/README.md)
+* [詞嵌入](14-Embeddings/README.md)
 * [語言建模](15-LanguageModeling/README.md)
 * [循環神經網絡](16-RNN/README.md)
 * [生成網絡](17-GenerativeNetworks/README.md)

--- a/translations/zh-TW/lessons/5-NLP/README.md
+++ b/translations/zh-TW/lessons/5-NLP/README.md
@@ -59,7 +59,7 @@ if len(physical_devices)>0:
 在本節中，我們將學習：
 
 * [將文本表示為張量](13-TextRep/README.md)
-* [詞嵌入](14-Emdeddings/README.md)
+* [詞嵌入](14-Embeddings/README.md)
 * [語言模型](15-LanguageModeling/README.md)
 * [循環神經網路](16-RNN/README.md)
 * [生成式網路](17-GenerativeNetworks/README.md)


### PR DESCRIPTION
### Summary
Fixes a broken link in the NLP lesson README caused by a typo in the directory reference (`14-Emdeddings` instead of `14-Embeddings`). The same typo existed identically across all 55 translated versions of the README, so this PR corrects it everywhere for consistency.

### Key Changes
- Corrected the `Word Embeddings` link in [lessons/5-NLP/README.md](https://github.com/microsoft/AI-For-Beginners/blob/main/lessons/5-NLP/README.md#in-this-section) from `14-Emdeddings/README.md` to `14-Embeddings/README.md`.
- Applied the same fix across all 55 translated READMEs under `translations/*/lessons/5-NLP/README.md`.
- Verified no remaining references to the misspelled `Emdeddings` path exist anywhere in the repo.
- Verified a `14-Embeddings` directory exists under every translation's `5-NLP` folder, so no corrected link is left dangling