### PR TITLE
docs: document Windows encoding workaround for Conda setup

### DIFF
--- a/lessons/0-course-setup/how-to-run.md
+++ b/lessons/0-course-setup/how-to-run.md
@@ -15,6 +15,36 @@ conda env create --name ai4beg --file .devcontainer/environment.yml
 conda activate ai4beg
 ```
 
+> **Windows note**: If environment creation fails while installing `gdk-pixbuf` with a `UnicodeDecodeError` that mentions the `gbk` codec, enable Python's UTF-8 mode in your terminal and retry. Use the syntax for the terminal you are using:
+>
+> **PowerShell:**
+>
+> ```powershell
+> $env:PYTHONUTF8 = "1"
+> conda env create --name ai4beg --file .devcontainer/environment.yml
+> ```
+>
+> **Command Prompt (`cmd.exe`) or Anaconda Prompt:**
+>
+> ```cmd
+> set PYTHONUTF8=1
+> conda env create --name ai4beg --file .devcontainer/environment.yml
+> ```
+>
+> **Bash, including Git Bash:**
+>
+> ```bash
+> export PYTHONUTF8=1
+> conda env create --name ai4beg --file .devcontainer/environment.yml
+> ```
+>
+> If a failed attempt left the `ai4beg` environment behind, deactivate it and remove that environment before retrying. Use `conda deactivate` first when an environment is active:
+>
+> ```text
+> conda deactivate
+> conda env remove --name ai4beg
+> ```
+
 ### Using Visual Studio Code with Python Extension
 
 This curriculum is best used when opening it in [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-77998-cacaste) with [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-77998-cacaste).

--- a/translations/zh-CN/lessons/0-course-setup/how-to-run.md
+++ b/translations/zh-CN/lessons/0-course-setup/how-to-run.md
@@ -15,6 +15,36 @@ conda env create --name ai4beg --file .devcontainer/environment.yml
 conda activate ai4beg
 ```
 
+> **Windows 注意事项**：如果创建环境时在安装 `gdk-pixbuf` 阶段失败，并出现提及 `gbk` 编码的 `UnicodeDecodeError`，请在您使用的终端中启用 Python UTF-8 模式，然后重试。请根据终端类型使用相应的语法：
+>
+> **PowerShell：**
+>
+> ```powershell
+> $env:PYTHONUTF8 = "1"
+> conda env create --name ai4beg --file .devcontainer/environment.yml
+> ```
+>
+> **命令提示符（`cmd.exe`）或 Anaconda Prompt：**
+>
+> ```cmd
+> set PYTHONUTF8=1
+> conda env create --name ai4beg --file .devcontainer/environment.yml
+> ```
+>
+> **Bash（包括 Git Bash）：**
+>
+> ```bash
+> export PYTHONUTF8=1
+> conda env create --name ai4beg --file .devcontainer/environment.yml
+> ```
+>
+> 如果失败的尝试留下了 `ai4beg` 环境，请先停用并删除该课程环境，然后再重试。如果当前已激活某个环境，请先运行 `conda deactivate`：
+>
+> ```text
+> conda deactivate
+> conda env remove --name ai4beg
+> ```
+
 ### 使用带 Python 扩展的 Visual Studio Code
 
 在 [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-77998-cacaste) 中打开本课程并安装 [Python 扩展](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-77998-cacaste)，是使用本课程的最佳方式。


### PR DESCRIPTION
## Summary

Document a workaround for Windows users who encounter a `UnicodeDecodeError`
while Conda is installing `gdk-pixbuf` during the course environment setup.

The issue is more likely to occur on Windows systems using a non-UTF-8 system
locale, such as GBK/CP936 on Simplified Chinese Windows. Other legacy code-page
configurations may be affected as well.

## Observed Error

When running:

```text
conda env create --name ai4beg --file .devcontainer/environment.yml
```

Conda may fail while installing:

```
defaults::gdk-pixbuf-2.44.6-hd37cd66_1
```

with an error similar to:

```
UnicodeDecodeError('gbk', b"g_module_open() failed for
C:\\Users\\<user>\\miniconda3\\envs\\ai4beg\\Library\\lib\\gdk-pixbuf-2.0\\2.10.0\\loaders\\libpixbufloader_svg.dll: ...")
```

In the affected environment, enabling Python UTF-8 mode before retrying allowed the environment creation command to proceed:

```
$env:PYTHONUTF8 = "1"
conda env create --name ai4beg --file .devcontainer/environment.yml
```

## Changes

- Document the encoding-related Windows failure mode.
- Add terminal-specific commands for PowerShell, Command Prompt/Anaconda Prompt,and Bash/Git Bash.

- Explain how to remove a partially created ai4beg environment before retrying.
- Synchronize the corresponding Simplified Chinese translation.

## Validation

- Ran git diff --check.
- Reviewed the Markdown code blocks and shell commands.
- No source code or dependency files were changed.
- Full environment recreation was not run because this is a documentation-only change.
