### PR TITLE
docs: fix typos in NLP lesson notebooks

### DIFF
--- a/lessons/5-NLP/14-Embeddings/EmbeddingsPyTorch.ipynb
+++ b/lessons/5-NLP/14-Embeddings/EmbeddingsPyTorch.ipynb
@@ -421,9 +421,9 @@
    "source": [
     "Both CBoW and Skip-Grams are “predictive” embeddings, in that they only take local contexts into account. Word2Vec does not take advantage of global context. \n",
     "\n",
-    "**FastText**, builds on Word2Vec by learning vector representations for each word and the charachter n-grams found within each word. The values of the representations are then averaged into one vector at each training step. While this adds a lot of additional computation to pre-training it enables word embeddings to encode sub-word information. \n",
+    "**FastText**, builds on Word2Vec by learning vector representations for each word and the character n-grams found within each word. The values of the representations are then averaged into one vector at each training step. While this adds a lot of additional computation to pre-training it enables word embeddings to encode sub-word information. \n",
     "\n",
-    "Another method, **GloVe**, leverages the idea of co-occurence matrix, uses neural methods to decompose co-occurrence matrix into more expressive and non linear word vectors.\n",
+    "Another method, **GloVe**, leverages the idea of co-occurrence matrix, uses neural methods to decompose co-occurrence matrix into more expressive and non linear word vectors.\n",
     "\n",
     "You can play with the example by changing embeddings to FastText and GloVe, since gensim supports several different word embedding models."
    ]

--- a/lessons/5-NLP/16-RNN/RNNTF.ipynb
+++ b/lessons/5-NLP/16-RNN/RNNTF.ipynb
@@ -292,7 +292,7 @@
       "source": [
         "Now that we're using masking, we can train the model on the whole dataset of titles and descriptions.\n",
         "\n",
-        "> **Note**: Have you noticed that we have been using vectorizer trained on the news titles, and not the whole body of the article? Potentially, this can cause some of the tokens to be ignored, so it is better to re-train the vectorizer. However, it might only have very small effect, so we will stick to the previous pre-trained vectorizer for the sake of simplicity."
+        "> **Note**: Have you noticed that we have been using a vectorizer trained on the news titles, and not the whole body of the article? Potentially, this can cause some of the tokens to be ignored, so it is better to re-train the vectorizer. However, it might only have a very small effect, so we will stick to the previous pre-trained vectorizer for the sake of simplicity."
       ]
     },
     {

--- a/lessons/5-NLP/16-RNN/RNNTF.ipynb
+++ b/lessons/5-NLP/16-RNN/RNNTF.ipynb
@@ -292,7 +292,7 @@
       "source": [
         "Now that we're using masking, we can train the model on the whole dataset of titles and descriptions.\n",
         "\n",
-        "> **Note**: Have you noticed that we have been using vectorizer trained on the news titles, and not the whole body of the article? Potentially, this can cause some of the the tokens to be ignored, so it is better to re-train the vectorizer. However, it might only have very small effect, so we will stick to the previous pre-trained vectorizer for the sake of simplicity."
+        "> **Note**: Have you noticed that we have been using vectorizer trained on the news titles, and not the whole body of the article? Potentially, this can cause some of the tokens to be ignored, so it is better to re-train the vectorizer. However, it might only have very small effect, so we will stick to the previous pre-trained vectorizer for the sake of simplicity."
       ]
     },
     {


### PR DESCRIPTION
﻿## Summary
Fix small documentation typos in two NLP lesson notebooks.

## Changes
- RNNTF.ipynb: remove duplicated word in a note
- EmbeddingsPyTorch.ipynb: fix character and co-occurrence spelling

## Testing
- Verified the edited markdown cells in notebook JSON
- No executable code or outputs were changed
