### PR TITLE
fix(06-IntroCV): missing braille dots

### DIFF
--- a/lessons/4-ComputerVision/06-IntroCV/OpenCV.ipynb
+++ b/lessons/4-ComputerVision/06-IntroCV/OpenCV.ipynb
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To work with images, we need to \"extract\" individual dots, i.e. convert the images to a set of coordinates of individual dots. Corner-based feature detectors such as SIFT, SURF or [ORB](https://docs.opencv.org/4.x/d1/d89/tutorial_py_orb.html) are not a great fit here: braille dots are uniform circular blobs rather than corners, so ORB ends up missing some of them. [`SimpleBlobDetector`](https://docs.opencv.org/4.x/d0/d7a/classcv_1_1SimpleBlobDetector.html) is designed to detect exactly this kind of blob:"
+    "To work with images, we need to \"extract\" individual dots, i.e. convert the images to a set of coordinates of individual dots. [`SimpleBlobDetector`](https://docs.opencv.org/4.x/d0/d7a/classcv_1_1SimpleBlobDetector.html) is designed to detect exactly this kind of blob:"
    ]
   },
   {

--- a/lessons/4-ComputerVision/06-IntroCV/OpenCV.ipynb
+++ b/lessons/4-ComputerVision/06-IntroCV/OpenCV.ipynb
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To work with images, we need to \"extract\" individual dots, i.e. convert the images to a set of coordinates of individual dots. We can do that using **feature extraction** techniques, such as SIFT, SURF or [ORB](https://docs.opencv.org/4.x/d1/d89/tutorial_py_orb.html):"
+    "To work with images, we need to \"extract\" individual dots, i.e. convert the images to a set of coordinates of individual dots. Corner-based feature detectors such as SIFT, SURF or [ORB](https://docs.opencv.org/4.x/d1/d89/tutorial_py_orb.html) are not a great fit here: braille dots are uniform circular blobs rather than corners, so ORB ends up missing some of them. [`SimpleBlobDetector`](https://docs.opencv.org/4.x/d0/d7a/classcv_1_1SimpleBlobDetector.html) is designed to detect exactly this kind of blob:"
    ]
   },
   {
@@ -204,13 +204,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "First 5 points: [(307.20001220703125, 40.80000305175781), (297.6000061035156, 114.00000762939453), (423.6000061035156, 133.20001220703125), (242.40000915527344, 144.0), (103.68000793457031, 57.60000228881836)]\n"
+      "First 5 points: [(76.5, 228.5), (55.14666748046875, 229.14666748046875), (335.5777893066406, 226.42222595214844), (281.0, 227.0), (229.14666748046875, 227.14666748046875)]\n"
      ]
     }
    ],
    "source": [
-    "orb = cv2.ORB_create(5000)\n",
-    "f,d = orb.detectAndCompute(im,None)\n",
+    "params = cv2.SimpleBlobDetector_Params()\n",
+    "params.filterByColor = True\n",
+    "params.blobColor = 255\n",
+    "params.filterByArea = True\n",
+    "params.minArea = 2\n",
+    "params.maxArea = 100\n",
+    "params.filterByCircularity = False\n",
+    "params.filterByConvexity = False\n",
+    "params.filterByInertia = False\n",
+    "params.minDistBetweenBlobs = 2\n",
+    "\n",
+    "detector = cv2.SimpleBlobDetector_create(params)\n",
+    "f = detector.detect(im)\n",
     "print(f\"First 5 points: { [f[i].pt for i in range(5)]}\")"
    ]
   },


### PR DESCRIPTION
ORB is a corner detector, so it misses some of the uniform circular dots in the braille image.

|The thresholded image|Extracted dots|
|--|--|
|<img width="552" height="274" alt="image" src="https://github.com/user-attachments/assets/d2794a07-217b-4f12-9eb8-38a694db6ae8" />|<img width="552" height="296" alt="image" src="https://github.com/user-attachments/assets/f02fa3d8-7e0c-4c20-afb9-3ec80a482c34" />|

 I suggest `SimpleBlobDetector` that detects them more reliably instead.

